### PR TITLE
fix(helper): Swift CI — macOS 14 availability + unused try? warning

### DIFF
--- a/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/DeviceWatcher.swift
+++ b/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/DeviceWatcher.swift
@@ -76,8 +76,19 @@ public final class DeviceWatcher {
 
     #if canImport(AVFoundation) && os(macOS)
     private func emit(kind: String) {
+        // macOS 14+ added a unified `.microphone` device type; the package
+        // still targets .macOS(.v13), so we fall back to the pre-14 set
+        // (.builtInMicrophone + .externalUnknown) on older systems. Both
+        // surface the same AVCaptureDevice instances for audio inputs, so
+        // the payload shape is identical downstream.
+        let deviceTypes: [AVCaptureDevice.DeviceType]
+        if #available(macOS 14.0, *) {
+            deviceTypes = [.microphone, .externalUnknown]
+        } else {
+            deviceTypes = [.builtInMicrophone, .externalUnknown]
+        }
         let session = AVCaptureDevice.DiscoverySession(
-            deviceTypes: [.microphone, .externalUnknown],
+            deviceTypes: deviceTypes,
             mediaType: .audio,
             position: .unspecified
         )

--- a/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/FileLog.swift
+++ b/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/FileLog.swift
@@ -47,7 +47,7 @@ public final class FileLog {
                 if FileManager.default.fileExists(atPath: logFile.path) {
                     if let handle = try? FileHandle(forWritingTo: logFile) {
                         defer { try? handle.close() }
-                        try? handle.seekToEnd()
+                        _ = try? handle.seekToEnd()
                         try? handle.write(contentsOf: data)
                     }
                 } else {


### PR DESCRIPTION
Fixes two CI blockers on the release build of the dictation helper:

1. `DeviceWatcher.swift` used `.microphone` (macOS 14+) while the package pins `.macOS(.v13)`. Now guarded with `#available(macOS 14, *)` and falls back to `.builtInMicrophone + .externalUnknown` on older systems.
2. `FileLog.swift` — `try? handle.seekToEnd()` with unused result failed under TreatWarningsAsErrors. Explicit `_ = try? …`.