### PR TITLE
feat(ui): animated TitleBar + onboarding guard fix + sidebar help

### DIFF
--- a/frontend/src/components/Layout/Layout.style.ts
+++ b/frontend/src/components/Layout/Layout.style.ts
@@ -2,7 +2,8 @@ import styled from "styled-components";
 
 export const LayoutRoot = styled.div`
   display: grid;
-  grid-template-columns: 240px 1fr;
+  /* Row 1: draggable TitleBar (44 px). Row 2: sidebar + main content. */
+  grid-template: 44px 1fr / 240px 1fr;
   height: 100vh;
   background: ${({ theme }) => theme.colors.bg.base};
 `;
@@ -13,7 +14,6 @@ export const Sidebar = styled.aside`
   padding: ${({ theme }) => theme.space(4)};
   background: ${({ theme }) => theme.colors.bg.elevated2};
   border-right: 1px solid ${({ theme }) => theme.colors.border.subtle};
-  -webkit-app-region: drag;
 `;
 
 export const Brand = styled.div`

--- a/frontend/src/components/Layout/Layout.style.ts
+++ b/frontend/src/components/Layout/Layout.style.ts
@@ -89,12 +89,46 @@ export const SidebarIconSlot = styled.span`
 export const SidebarFooter = styled.div`
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: ${({ theme }) => theme.space(2)};
   padding-top: ${({ theme }) => theme.space(3)};
   border-top: 1px solid ${({ theme }) => theme.colors.border.subtle};
   font-size: ${({ theme }) => theme.font.size.xs};
   color: ${({ theme }) => theme.colors.text.secondary};
   -webkit-app-region: no-drag;
+`;
+
+export const SidebarStatus = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.space(2)};
+`;
+
+export const HelpButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  border-radius: ${({ theme }) => theme.radii.full};
+  background: transparent;
+  color: ${({ theme }) => theme.colors.text.secondary};
+  cursor: pointer;
+  transition: background ${({ theme }) => theme.motion.duration.fast},
+    color ${({ theme }) => theme.motion.duration.fast};
+  -webkit-app-region: no-drag;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.bg.base};
+    color: ${({ theme }) => theme.colors.accent.primary};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.colors.focusRing};
+    outline-offset: 2px;
+  }
 `;
 
 export const StatusDot = styled.span<{ $ok: boolean }>`

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -1,14 +1,30 @@
 import { FC, ReactNode } from "react";
-import { NavLink, useLocation } from "react-router-dom";
+import { NavLink, useLocation, useNavigate } from "react-router-dom";
+import { useDispatch } from "react-redux";
 import { useTranslation } from "react-i18next";
-import { Archive, Brain, Database, FolderCog, FolderTree, ListTree, MessageSquare, RefreshCw, Settings, Sparkles, Wrench } from "lucide-react";
+import {
+  Archive,
+  Brain,
+  Database,
+  FolderCog,
+  FolderTree,
+  HelpCircle,
+  ListTree,
+  MessageSquare,
+  RefreshCw,
+  Settings,
+  Sparkles,
+  Wrench,
+} from "lucide-react";
 
 import { useBackendHealth } from "../../hooks/useBackendHealth";
 import { ROUTES } from "../../constants/routes";
+import { resetOnboarding } from "../../store/slices/onboarding";
 import TitleBar from "../TitleBar";
 import {
   BackendStatusBanner,
   Content,
+  HelpButton,
   LayoutRoot,
   Sidebar,
   SidebarFooter,
@@ -16,6 +32,7 @@ import {
   SidebarIconSlot,
   SidebarItem,
   SidebarSection,
+  SidebarStatus,
   StatusDot,
 } from "./Layout.style";
 
@@ -27,7 +44,19 @@ const Layout: FC<LayoutProps> = ({ children }) => {
   const { t } = useTranslation();
   const health = useBackendHealth();
   const location = useLocation();
+  const navigate = useNavigate();
+  // react-redux v9 expects `UnknownAction` with an index-signature; our slice
+  // actions are discriminated unions. Widen at dispatch time (mirrors
+  // features/Sync/Sync.tsx) — type safety of the action is enforced by the
+  // creator functions themselves.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dispatch = useDispatch() as (action: any) => void;
   const isHealthy = health.status === "ok";
+
+  const onRestartOnboarding = () => {
+    dispatch(resetOnboarding());
+    navigate(ROUTES.onboarding);
+  };
 
   return (
     <LayoutRoot>
@@ -78,8 +107,19 @@ const Layout: FC<LayoutProps> = ({ children }) => {
         </SidebarSection>
 
         <SidebarFooter>
-          <StatusDot $ok={isHealthy} />
-          {isHealthy ? t("backendHealth.online") : t("backendHealth.offline")}
+          <SidebarStatus>
+            <StatusDot $ok={isHealthy} />
+            {isHealthy ? t("backendHealth.online") : t("backendHealth.offline")}
+          </SidebarStatus>
+          <HelpButton
+            type="button"
+            aria-label={t("sidebar.restartOnboarding")}
+            title={t("sidebar.restartOnboarding")}
+            onClick={onRestartOnboarding}
+            data-testid="sidebar-restart-onboarding"
+          >
+            <HelpCircle size={18} />
+          </HelpButton>
         </SidebarFooter>
       </Sidebar>
       <Content>

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -5,6 +5,7 @@ import { Archive, Brain, Database, FolderCog, FolderTree, ListTree, MessageSquar
 
 import { useBackendHealth } from "../../hooks/useBackendHealth";
 import { ROUTES } from "../../constants/routes";
+import TitleBar from "../TitleBar";
 import {
   BackendStatusBanner,
   Content,
@@ -30,6 +31,7 @@ const Layout: FC<LayoutProps> = ({ children }) => {
 
   return (
     <LayoutRoot>
+      <TitleBar />
       <Sidebar>
         <SidebarSection>
           <SidebarGroup>

--- a/frontend/src/components/Layout/__tests__/Layout.test.tsx
+++ b/frontend/src/components/Layout/__tests__/Layout.test.tsx
@@ -1,0 +1,66 @@
+import { ReactNode } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { Provider } from "react-redux";
+import { applyMiddleware, createStore, type Middleware } from "redux";
+import { ThemeProvider } from "styled-components";
+
+import Layout from "../Layout";
+import { ROUTES } from "../../../constants/routes";
+import { rootReducer } from "../../../store/rootReducer";
+import { RESET_ONBOARDING } from "../../../store/slices/onboarding";
+import { darkTheme } from "../../../styles/theme";
+import "../../../i18n";
+
+// The Layout renders `useBackendHealth`, which fires real axios requests. Stub
+// it so no network traffic hits jsdom during the test. We only care about the
+// help-button behaviour here.
+jest.mock("../../../hooks/useBackendHealth", () => ({
+  useBackendHealth: () => ({ status: "ok", lastCheckedAt: new Date() }),
+}));
+
+const OnboardingMock = () => <div data-testid="onboarding-marker">onboarding</div>;
+
+describe("Layout help button", () => {
+  it("dispatches RESET_ONBOARDING and navigates to /onboarding on click", () => {
+    const dispatched: string[] = [];
+    const spyMiddleware: Middleware = () => (next) => (action: unknown) => {
+      if (action && typeof (action as { type?: unknown }).type === "string") {
+        dispatched.push((action as { type: string }).type);
+      }
+      return next(action);
+    };
+    const store = createStore(rootReducer, applyMiddleware(spyMiddleware));
+
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <Provider store={store}>
+        <ThemeProvider theme={darkTheme}>{children}</ThemeProvider>
+      </Provider>
+    );
+
+    render(
+      <MemoryRouter initialEntries={[ROUTES.home]}>
+        <Routes>
+          <Route
+            path="/*"
+            element={
+              <Layout>
+                <div data-testid="page-body">home page</div>
+              </Layout>
+            }
+          />
+          <Route path={ROUTES.onboarding} element={<OnboardingMock />} />
+        </Routes>
+      </MemoryRouter>,
+      { wrapper: Wrapper },
+    );
+
+    const button = screen.getByTestId("sidebar-restart-onboarding");
+    fireEvent.click(button);
+
+    expect(dispatched).toContain(RESET_ONBOARDING);
+    // After navigation the MemoryRouter unmounts Layout and mounts the
+    // onboarding route — its marker is the observable evidence of routing.
+    expect(screen.getByTestId("onboarding-marker")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/TitleBar/TitleBar.style.ts
+++ b/frontend/src/components/TitleBar/TitleBar.style.ts
@@ -1,0 +1,47 @@
+import styled, { keyframes } from "styled-components";
+
+/**
+ * Slow diagonal breathing used by the TitleBar. We animate `background-position`
+ * rather than the gradient itself so there's no per-frame shader-paint cost —
+ * the GPU simply pans the pre-composited gradient across an oversized canvas.
+ */
+const breathe = keyframes`
+  0% { background-position: 0% 50%; }
+  100% { background-position: 100% 50%; }
+`;
+
+export const TitleBarRoot = styled.header`
+  grid-column: 1 / -1;
+  height: 44px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: ${({ theme }) => theme.space(2)};
+  /* 78 px left reservation keeps the macOS traffic-light buttons
+     (titleBarStyle: "hiddenInset") clear of bar content. */
+  padding: 0 ${({ theme }) => theme.space(4)} 0 78px;
+  color: ${({ theme }) => theme.colors.text.primary};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border.subtle};
+  background: linear-gradient(
+    135deg,
+    ${({ theme }) => theme.colors.accent.primary} 0%,
+    ${({ theme }) => theme.colors.bg.elevated1} 100%
+  );
+  background-size: 200% 200%;
+  animation: ${breathe} 9s ease-in-out infinite alternate;
+  -webkit-app-region: drag;
+  user-select: none;
+`;
+
+export const TitleBarLabel = styled.span`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.semibold};
+  letter-spacing: 0.02em;
+`;
+
+export const TitleBarIconSlot = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/frontend/src/components/TitleBar/TitleBar.tsx
+++ b/frontend/src/components/TitleBar/TitleBar.tsx
@@ -1,0 +1,29 @@
+import { FC } from "react";
+import { useTranslation } from "react-i18next";
+import { Sparkles } from "lucide-react";
+
+import { TitleBarIconSlot, TitleBarLabel, TitleBarRoot } from "./TitleBar.style";
+
+/**
+ * Chrome-less window titlebar for the main BrowserWindow.
+ *
+ * - Spans the full window width and serves as the primary
+ *   `-webkit-app-region: drag` target (Electron hiddenInset mode).
+ * - Pads 78 px on the left so macOS traffic-light buttons have room.
+ * - Background is a slow diagonal "breathing" gradient between the accent
+ *   green and the neutral elevated-1 surface — see `TitleBar.style.ts`.
+ */
+const TitleBar: FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <TitleBarRoot>
+      <TitleBarIconSlot>
+        <Sparkles size={14} aria-hidden="true" />
+      </TitleBarIconSlot>
+      <TitleBarLabel>{t("app.name")}</TitleBarLabel>
+    </TitleBarRoot>
+  );
+};
+
+export default TitleBar;

--- a/frontend/src/components/TitleBar/__tests__/TitleBar.test.tsx
+++ b/frontend/src/components/TitleBar/__tests__/TitleBar.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "styled-components";
+
+import TitleBar from "../TitleBar";
+import { darkTheme } from "../../../styles/theme";
+import "../../../i18n";
+
+describe("TitleBar", () => {
+  it("renders the application name as its draggable label", () => {
+    render(
+      <ThemeProvider theme={darkTheme}>
+        <TitleBar />
+      </ThemeProvider>,
+    );
+
+    // The label must surface the localised app.name ("Mozgoslav" / "Мозгослав").
+    const header = screen.getByRole("banner");
+    expect(header).toBeInTheDocument();
+    expect(header.textContent).toMatch(/мозгослав|mozgoslav/i);
+  });
+
+  it("exposes a header landmark dedicated to window-drag", () => {
+    const { container } = render(
+      <ThemeProvider theme={darkTheme}>
+        <TitleBar />
+      </ThemeProvider>,
+    );
+
+    // jsdom does not resolve styled-component rules, so inspect the generated
+    // stylesheet for the `-webkit-app-region: drag` rule that ships with the
+    // root header. This guards against a regression where the drag region
+    // accidentally moves back to the sidebar.
+    const styleTags = Array.from(container.ownerDocument.querySelectorAll("style"));
+    const combined = styleTags.map((tag) => tag.textContent ?? "").join("\n");
+    expect(combined).toMatch(/-webkit-app-region:\s*drag/);
+  });
+});

--- a/frontend/src/components/TitleBar/index.ts
+++ b/frontend/src/components/TitleBar/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TitleBar";

--- a/frontend/src/guards/OnboardingCompleteGuard.tsx
+++ b/frontend/src/guards/OnboardingCompleteGuard.tsx
@@ -1,20 +1,21 @@
 import { FC, PropsWithChildren } from "react";
+import { useSelector } from "react-redux";
 import { Navigate } from "react-router-dom";
 
 import { ROUTES } from "../constants/routes";
+import { selectOnboardingCompleted } from "../store/slices/onboarding";
 
 /**
  * Blocks a route until the user has completed (or skipped to completion)
- * the onboarding wizard.
- *
- * TEMP (task #15, 2026-04-18): during active development the guard always
- * redirects to onboarding so changes to the wizard are visible on every
- * launch. To revert when onboarding stabilises: restore the previous
- * localStorage-based implementation from git history (also fixes Skip via
- * task #14).
+ * the onboarding wizard. The source of truth is the Redux `onboarding.completed`
+ * flag, which is hydrated from the backend via `watchOnboardingSagas`.
  */
-const OnboardingCompleteGuard: FC<PropsWithChildren> = () => {
-  return <Navigate to={ROUTES.onboarding} replace />;
+const OnboardingCompleteGuard: FC<PropsWithChildren> = ({ children }) => {
+  const completed = useSelector(selectOnboardingCompleted);
+  if (!completed) {
+    return <Navigate to={ROUTES.onboarding} replace />;
+  }
+  return <>{children}</>;
 };
 
 export default OnboardingCompleteGuard;

--- a/frontend/src/guards/__tests__/OnboardingCompleteGuard.test.tsx
+++ b/frontend/src/guards/__tests__/OnboardingCompleteGuard.test.tsx
@@ -1,46 +1,54 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { Provider } from "react-redux";
+import { combineReducers, createStore } from "redux";
 
 import OnboardingCompleteGuard from "../OnboardingCompleteGuard";
 import { ROUTES } from "../../constants/routes";
-import { ONBOARDING_COMPLETE_STORAGE_KEY } from "../../store/slices/onboarding";
+import { completionLoaded, onboardingReducer } from "../../store/slices/onboarding";
 
 const ProtectedPage = () => <div data-testid="protected">protected-content</div>;
 const OnboardingPage = () => <div data-testid="onboarding">onboarding-content</div>;
 
-const renderGuarded = (initialPath: string) =>
-  render(
-    <MemoryRouter initialEntries={[initialPath]}>
-      <Routes>
-        <Route path={ROUTES.onboarding} element={<OnboardingPage />} />
-        <Route
-          path="/protected"
-          element={
-            <OnboardingCompleteGuard>
-              <ProtectedPage />
-            </OnboardingCompleteGuard>
-          }
-        />
-      </Routes>
-    </MemoryRouter>,
+const renderGuarded = (initialPath: string, completed: boolean) => {
+  // Use the real onboarding reducer; dispatch `completionLoaded(completed)` to
+  // seed state exactly like the persist saga would on boot.
+  const store = createStore(combineReducers({ onboarding: onboardingReducer }));
+  // redux v5 dispatch expects `UnknownAction` (index-signature); our slice
+  // actions are discriminated unions. Widen locally, mirroring the dispatch
+  // pattern in features/Sync/Sync.tsx and components/Layout/Layout.tsx.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (store.dispatch as (action: any) => void)(completionLoaded(completed));
+
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path={ROUTES.onboarding} element={<OnboardingPage />} />
+          <Route
+            path="/protected"
+            element={
+              <OnboardingCompleteGuard>
+                <ProtectedPage />
+              </OnboardingCompleteGuard>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
   );
+};
 
-describe("OnboardingCompleteGuard (TEMP dev override — task #15)", () => {
-  afterEach(() => {
-    window.localStorage.clear();
+describe("OnboardingCompleteGuard", () => {
+  it("renders children when onboarding has been completed", () => {
+    renderGuarded("/protected", true);
+
+    expect(screen.getByTestId("protected")).toBeInTheDocument();
+    expect(screen.queryByTestId("onboarding")).toBeNull();
   });
 
-  it("redirects to onboarding even when completion flag is set to true", () => {
-    window.localStorage.setItem(ONBOARDING_COMPLETE_STORAGE_KEY, "true");
-
-    renderGuarded("/protected");
-
-    expect(screen.queryByTestId("protected")).toBeNull();
-    expect(screen.getByTestId("onboarding")).toBeInTheDocument();
-  });
-
-  it("redirects to onboarding when completion flag is absent", () => {
-    renderGuarded("/protected");
+  it("redirects to onboarding when the completion flag is false", () => {
+    renderGuarded("/protected", false);
 
     expect(screen.queryByTestId("protected")).toBeNull();
     expect(screen.getByTestId("onboarding")).toBeInTheDocument();

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -60,6 +60,9 @@
     "offline": "Backend not responding",
     "hint": "Start the backend: `dotnet run` inside backend/"
   },
+  "sidebar": {
+    "restartOnboarding": "Restart onboarding"
+  },
   "dashboard": {
     "title": "Dashboard",
     "importTitle": "Add recording",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -60,6 +60,9 @@
     "offline": "Бэкенд не отвечает",
     "hint": "Запусти backend: `dotnet run` в папке backend/"
   },
+  "sidebar": {
+    "restartOnboarding": "Заново пройти онбординг"
+  },
   "dashboard": {
     "title": "Дашборд",
     "importTitle": "Добавить запись",


### PR DESCRIPTION
## Summary
- Animated TitleBar (44 px, diagonal breathing gradient, drag moved from Sidebar, 78 px left pad for macOS traffic lights)
- `OnboardingCompleteGuard` restored to real `selectOnboardingCompleted` check (TEMP hack from 89d1c31 removed)
- Sidebar `HelpCircle` button: dispatches `resetOnboarding` + navigates to `/onboarding`

## Test plan
- [ ] `npm run typecheck` green
- [ ] `npm run lint` green
- [ ] `npm test` green (147/147 locally)
- [ ] macOS QA: animation smoothness, traffic-light clearance, hover/focus visuals