### PR TITLE
fix(worker): don't touch scoped DbContext from Progress<int> ticks

### DIFF
--- a/backend/src/Mozgoslav.Application/UseCases/ProcessQueueWorker.cs
+++ b/backend/src/Mozgoslav.Application/UseCases/ProcessQueueWorker.cs
@@ -161,7 +161,7 @@ public sealed class ProcessQueueWorker
 
         var wavPath = await _audioConverter.ConvertToWavAsync(recording.FilePath, ct);
 
-        var segmentProgress = new Progress<int>(p => _ = UpdateProgressAsync(job, ScaleProgress(p, 0, TranscribeEnd), ct));
+        var segmentProgress = new Progress<int>(p => _ = NotifyProgressAsync(job, ScaleProgress(p, 0, TranscribeEnd), ct));
         // Plan v0.8 Block 5 — glossary drives Whisper `initial_prompt`. Empty
         // glossary → null → existing behaviour (no prompt override).
         var whisperInitialPrompt = _glossary.TryBuildInitialPrompt(profile);
@@ -273,10 +273,22 @@ public sealed class ProcessQueueWorker
         await _progressNotifier.PublishAsync(job, ct);
     }
 
-    private async Task UpdateProgressAsync(ProcessingJob job, int progress, CancellationToken ct)
+    /// <summary>
+    /// Progress tick from <see cref="Progress{T}"/> handlers — fired on pool
+    /// threads concurrently with the main pipeline and with each other. MUST
+    /// NOT touch the scoped DbContext: concurrent <c>SaveChangesAsync</c>
+    /// calls on a single context trip EF Core's <c>ConcurrencyDetector</c>
+    /// (InvalidOperationException "A second operation was started...") or —
+    /// worse — corrupt the change tracker and surface later as
+    /// <c>NullReferenceException</c> inside <c>StateManager.CascadeChanges</c>.
+    /// Progress ticks are a UI concern; they travel via SSE only. Durable
+    /// progress is persisted on stage boundaries in
+    /// <see cref="TransitionAsync"/>, which runs awaited on the pipeline's
+    /// single logical thread.
+    /// </summary>
+    private async Task NotifyProgressAsync(ProcessingJob job, int progress, CancellationToken ct)
     {
         job.Progress = progress;
-        await _jobs.UpdateAsync(job, ct);
         await _progressNotifier.PublishAsync(job, ct);
     }
 


### PR DESCRIPTION
ProcessQueueWorker.RunPipelineAsync line 164 wired `new Progress<int>(p => _ = UpdateProgressAsync(job, ..., ct))`, a fire-and-forget handler invoked from pool threads by Whisper's streaming segment emitter. UpdateProgressAsync then called _jobs.UpdateAsync → _db.SaveChangesAsync on the SCOPED DbContext that was simultaneously being written by the main pipeline (AddAsync on Transcript, UpdateAsync on ProcessingJob between stages).

EF Core's ConcurrencyDetector caught the race as
"A second operation was started on this context instance before a previous operation completed"; when the detector missed the first slot the change tracker corrupted and threw
NullReferenceException in StateManager.CascadeChanges — both faces of the same root cause.

Fix: drop the DB write from NotifyProgressAsync. Progress ticks are a UI concern and flow over SSE only (ChannelJobProgressNotifier is thread-safe). Durable progress is persisted on stage boundaries by TransitionAsync, which runs awaited on the pipeline's single logical thread and is safe.

Side effects of the same race that will also go away:
- recording.Duration = segments[^1].End; UpdateAsync(...) no longer collides → duration stops being 0 in the exported markdown frontmatter.
- Transcript / ProcessedNote adds no longer race against the progress writes → stray tracker corruption cases disappear.

No behaviour change on happy path beyond: progress now advances in stage-sized jumps between transitions and smoothly over SSE for UI.