### PR TITLE
fix(helper): prompt macOS Accessibility on hotkey start

### DIFF
--- a/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/DictationHelper.swift
+++ b/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/DictationHelper.swift
@@ -128,6 +128,25 @@ public final class DictationHelper {
                 "inputMonitoring": .string(inputMonitoring),
             ]))
 
+        case "permission.request":
+            // NEXT H1 fix — expose the native Accessibility / Input Monitoring
+            // prompts to the renderer so the Onboarding wizard can trigger
+            // them from a button click. `opened*` is true when we had to fall
+            // back to the System Settings deeplink because the OS suppressed
+            // the automatic prompt (user already denied once).
+            let accessibility = PermissionProbe.requestAccessibility()
+            let inputMonitoring = PermissionProbe.requestInputMonitoring()
+            var openedAccessibility = false
+            if !accessibility {
+                PermissionProbe.openAccessibilitySettings()
+                openedAccessibility = true
+            }
+            return JsonRpcResponse(id: request.id, result: .object([
+                "accessibility": .bool(accessibility),
+                "inputMonitoring": .bool(inputMonitoring),
+                "openedAccessibilitySettings": .bool(openedAccessibility),
+            ]))
+
         case "inject.text":
             let params = request.params?.objectValue() ?? [:]
             let text = params["text"]?.stringValue() ?? ""

--- a/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/HotkeyMonitor.swift
+++ b/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/HotkeyMonitor.swift
@@ -29,6 +29,7 @@ public final class HotkeyMonitor {
     private let isoFormatter: ISO8601DateFormatter
     private var parsed: ParsedAccelerator?
     private var holding: Bool = false
+    private var didRequestPermissionsOnce: Bool = false
 
     #if canImport(AppKit) && os(macOS)
     private var keyDownMonitor: Any?
@@ -55,6 +56,26 @@ public final class HotkeyMonitor {
         self.parsed = parsed
 
         #if canImport(AppKit) && os(macOS)
+        // `NSEvent.addGlobalMonitorForEvents` silently returns a no-op
+        // observer when the helper process lacks Accessibility (and often
+        // Input Monitoring). On the first `start` per process we trigger
+        // the native macOS prompts — that educates first-run users and
+        // makes the underlying failure mode visible in the FileLog.
+        // Subsequent starts re-check without re-opening Settings, so we
+        // don't nag after every settings save.
+        let accessibilityGranted = PermissionProbe.accessibilityStatus() == "granted"
+        if !didRequestPermissionsOnce {
+            didRequestPermissionsOnce = true
+            _ = PermissionProbe.requestAccessibility()
+            _ = PermissionProbe.requestInputMonitoring()
+            if !accessibilityGranted {
+                FileLog.shared.warn(
+                    "H1 HotkeyMonitor: Accessibility not granted — opening System Settings"
+                )
+                PermissionProbe.openAccessibilitySettings()
+            }
+        }
+
         keyDownMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
             self?.handleKey(event: event, kind: "press")
         }
@@ -70,7 +91,7 @@ public final class HotkeyMonitor {
             _ = self
         }
         FileLog.shared.info(
-            "H1 HotkeyMonitor started for accelerator='\(trimmed)'"
+            "H1 HotkeyMonitor started for accelerator='\(trimmed)' accessibilityGranted=\(accessibilityGranted)"
         )
         #else
         _ = parsed

--- a/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/PermissionProbe.swift
+++ b/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/PermissionProbe.swift
@@ -8,6 +8,10 @@ import AVFoundation
 import ApplicationServices
 #endif
 
+#if canImport(AppKit) && os(macOS)
+import AppKit
+#endif
+
 /// macOS permission probes for the Onboarding wizard (plan/v0.8/04-onboarding-slim.md §3).
 /// Returns one of "granted" / "denied" / "undetermined" so the UI can branch
 /// without re-implementing the Apple API surface.
@@ -35,13 +39,9 @@ public enum PermissionProbe {
     }
 
     public static func inputMonitoringStatus() -> String {
-        // Apple does not expose a public authorization API for input
-        // monitoring — we probe CGEventSourceSecondaryKeyboardType to infer
-        // whether the process can observe input events.
-        // This is the same approach used by popular utilities (e.g.
-        // Monitor Control, Alfred).
         #if canImport(ApplicationServices)
-        let trusted = IOHIDCheckAccess?(kIOHIDRequestTypeListenEvent)
+        guard let fn = IOHIDCheckAccess else { return "undetermined" }
+        let trusted = fn(kIOHIDRequestTypeListenEvent)
         switch trusted {
         case kIOHIDAccessTypeGranted: return "granted"
         case kIOHIDAccessTypeDenied: return "denied"
@@ -52,18 +52,85 @@ public enum PermissionProbe {
         return "undetermined"
         #endif
     }
+
+    /// Triggers the native macOS Accessibility prompt via
+    /// `AXIsProcessTrustedWithOptions([kAXTrustedCheckOptionPrompt: true])`.
+    /// Returns the post-call trust state. If the user already denied once,
+    /// macOS suppresses further prompts — callers should follow up with
+    /// `openAccessibilitySettings()`.
+    public static func requestAccessibility() -> Bool {
+        #if canImport(ApplicationServices)
+        let promptKey = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
+        let options: CFDictionary = [promptKey: true] as CFDictionary
+        return AXIsProcessTrustedWithOptions(options)
+        #else
+        return false
+        #endif
+    }
+
+    /// Invokes `IOHIDRequestAccess(kIOHIDRequestTypeListenEvent)` to show the
+    /// native Input Monitoring prompt. Resolved dynamically — same reason as
+    /// `IOHIDCheckAccess`: stay compatible with SDKs that don't surface the
+    /// symbol at build time. Falls back to `false` when unavailable.
+    public static func requestInputMonitoring() -> Bool {
+        #if canImport(ApplicationServices)
+        guard let fn = IOHIDRequestAccess else { return false }
+        return fn(kIOHIDRequestTypeListenEvent)
+        #else
+        return false
+        #endif
+    }
+
+    /// Escape hatch for the re-prompt-suppressed case — deeplinks the user
+    /// straight into System Settings → Privacy → Accessibility.
+    public static func openAccessibilitySettings() {
+        #if canImport(AppKit) && os(macOS)
+        guard let url = URL(
+            string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+        ) else { return }
+        NSWorkspace.shared.open(url)
+        #endif
+    }
+
+    /// Same escape hatch for Input Monitoring.
+    public static func openInputMonitoringSettings() {
+        #if canImport(AppKit) && os(macOS)
+        guard let url = URL(
+            string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
+        ) else { return }
+        NSWorkspace.shared.open(url)
+        #endif
+    }
 }
 
-// Dynamic lookup so we compile on older SDKs that do not expose IOHIDCheckAccess
-// at build time (only macOS 10.15+). A forward-declared optional binding is all
-// we need — runtime resolution falls back to "undetermined" when missing.
+// Dynamic lookup of IOKit HID authorisation APIs. We keep this pattern so the
+// file compiles against older SDKs that did not export the symbols at build
+// time — runtime resolution simply yields `nil` / "undetermined" in that case.
 #if canImport(ApplicationServices)
+private typealias IOHIDAccessCheckFn = @convention(c) (Int) -> Int
+private typealias IOHIDAccessRequestFn = @convention(c) (Int) -> Bool
+
+private let ioKitHandle: UnsafeMutableRawPointer? = dlopen(
+    "/System/Library/Frameworks/IOKit.framework/IOKit",
+    RTLD_LAZY
+)
+
 private let IOHIDCheckAccess: ((Int) -> Int)? = {
-    // Return nil so we always fall through to "undetermined" — the Onboarding
-    // wizard treats undetermined as "request permission via deep link", which
-    // is the correct behaviour for every macOS version.
-    return nil
+    guard let handle = ioKitHandle, let sym = dlsym(handle, "IOHIDCheckAccess") else {
+        return nil
+    }
+    let fn = unsafeBitCast(sym, to: IOHIDAccessCheckFn.self)
+    return { type in fn(type) }
 }()
+
+private let IOHIDRequestAccess: ((Int) -> Bool)? = {
+    guard let handle = ioKitHandle, let sym = dlsym(handle, "IOHIDRequestAccess") else {
+        return nil
+    }
+    let fn = unsafeBitCast(sym, to: IOHIDAccessRequestFn.self)
+    return { type in fn(type) }
+}()
+
 private let kIOHIDRequestTypeListenEvent = 1
 private let kIOHIDAccessTypeGranted = 0
 private let kIOHIDAccessTypeDenied = 1


### PR DESCRIPTION
## Root cause

Dictation hotkey is silently dead on first run because three gaps stack:

1. `HotkeyMonitor.start()` calls `NSEvent.addGlobalMonitorForEvents` without first ensuring Accessibility — macOS returns a no-op observer, nothing fires, no error.
2. `PermissionProbe` had no `request*` surface, so Onboarding had no way to trigger the native macOS prompt.
3. `PermissionProbe.inputMonitoringStatus()` was a deliberate nil-stub — the inline comment even said so — always returning `"undetermined"`, hiding the actual Input Monitoring state.

Combined: helper spawns, hotkey looks configured in settings, yet no keys are captured and no UX signal tells the user permissions are the cause.

## Changes

- `PermissionProbe.swift` — add `requestAccessibility()`, `requestInputMonitoring()` (via dlsym `IOHIDRequestAccess` for SDK portability), plus `openAccessibilitySettings()` / `openInputMonitoringSettings()` deeplinks for the suppressed-prompt case. Repair `inputMonitoringStatus()` to honour the real `IOHIDCheckAccess` result.
- `HotkeyMonitor.swift` — on the first `start(accelerator:)` per process, trigger the native prompts. If Accessibility is still not granted after the prompt, FileLog warn + open System Settings. Subsequent starts re-check without nagging. `started` log line now carries `accessibilityGranted=<bool>` so the failure mode is visible in `~/Library/Logs/Mozgoslav/helper-*.log`.
- `DictationHelper.swift` — expose `permission.request` JSON-RPC so Onboarding can call it from a button.

## Test plan

- [ ] `cd helpers/MozgoslavDictationHelper && swift build -c release` (macOS 13+)
- [ ] Kill the old helper: `pkill -f mozgoslav-dictation-helper`
- [ ] Launch Mozgoslav, confirm ticket: first hotkey press after fresh install surfaces the macOS Accessibility prompt. Grant, restart app.
- [ ] Verify `~/Library/Logs/Mozgoslav/helper-*.log` shows `H1 HotkeyMonitor started for accelerator='...' accessibilityGranted=true`.
- [ ] Re-test on a build where the user previously denied Accessibility — System Settings should open on the Accessibility pane.
- [ ] Onboarding can call `permission.request` and receives `{accessibility, inputMonitoring, openedAccessibilitySettings}` — UI wiring is optional follow-up.

## Known limits

- macOS caches AX trust per PID — after granting permission the app must be relaunched for monitors to actually fire. This is a macOS constraint, not something the patch can eliminate. Follow-up: detect the freshly-granted state and nudge user to relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)