### PR TITLE
fix(helper+onboarding+electron): AppKit run loop, system-prefs deeplink, quit on close

### DIFF
--- a/frontend/electron/main.ts
+++ b/frontend/electron/main.ts
@@ -445,10 +445,14 @@ const walkForConflicts = async (
   return results;
 };
 
+// Closing the main window tears down the whole app, including the ASP.NET
+// backend and the Swift dictation helper. Per-user preference: a Mozgoslav
+// without a window is not useful, and leaving orphaned `dotnet` / helper
+// processes running in the background is the top paper-cut on macOS. We
+// diverge from the default AppKit semantics (where the app stays resident)
+// on purpose — `before-quit` handles the actual cleanup.
 app.on("window-all-closed", () => {
-  if (process.platform !== "darwin") {
-    app.quit();
-  }
+  app.quit();
 });
 
 app.on("before-quit", () => {

--- a/frontend/electron/main.ts
+++ b/frontend/electron/main.ts
@@ -215,6 +215,32 @@ app.whenReady().then(async () => {
     return error || undefined;
   });
 
+  // Onboarding permission cards need to deeplink into System Settings
+  // (`x-apple.systempreferences:…`). `window.open` is blocked for non-http
+  // URLs by `setWindowOpenHandler` above, so we route via IPC and gate
+  // forwarding to a known-safe scheme whitelist — renderer-originating URLs
+  // must not be able to reach arbitrary OS handlers.
+  const EXTERNAL_URL_PREFIXES = [
+    "http://",
+    "https://",
+    "mailto:",
+    "x-apple.systempreferences:",
+  ] as const;
+  ipcMain.handle("shell:openExternal", async (_, url: string) => {
+    if (typeof url !== "string") return false;
+    if (!EXTERNAL_URL_PREFIXES.some((prefix) => url.startsWith(prefix))) {
+      console.warn(`[shell:openExternal] rejected non-whitelisted URL: ${url}`);
+      return false;
+    }
+    try {
+      await shell.openExternal(url);
+      return true;
+    } catch (error) {
+      console.error("[shell:openExternal] failed:", error);
+      return false;
+    }
+  });
+
   // BC-033 — model-file picker filters to Whisper/VAD extensions.
   ipcMain.handle("dialog:openModelFile", async () => {
     if (!mainWindow) return { canceled: true, filePaths: [] };

--- a/frontend/electron/preload.ts
+++ b/frontend/electron/preload.ts
@@ -9,6 +9,17 @@ export interface MozgoslavBridge {
   openAudioFiles: () => Promise<{ canceled: boolean; filePaths: string[] }>;
   openFolder: () => Promise<{ canceled: boolean; filePaths: string[] }>;
   openPath: (path: string) => Promise<string | undefined>;
+  /**
+   * Opens a URL in the user's default handler via Electron's `shell.openExternal`.
+   * Only a fixed set of schemes is forwarded by the main-process handler
+   * (http, https, mailto, x-apple.systempreferences); anything else is refused
+   * so renderer-originating URLs cannot reach arbitrary OS handlers.
+   *
+   * Primary use: the Onboarding permissions cards need to deeplink into
+   * System Settings; `window.open("x-apple.systempreferences:…")` is silently
+   * blocked by the hardened `setWindowOpenHandler` that only allows http(s).
+   */
+  openExternal: (url: string) => Promise<boolean>;
   openModelFile: () => Promise<{ canceled: boolean; filePaths: string[] }>;
   openModelFolder: () => Promise<{ canceled: boolean; filePaths: string[] }>;
   listSyncConflicts: (
@@ -49,6 +60,7 @@ const bridge: MozgoslavBridge = {
   openAudioFiles: () => ipcRenderer.invoke("dialog:openAudioFiles"),
   openFolder: () => ipcRenderer.invoke("dialog:openFolder"),
   openPath: (path) => ipcRenderer.invoke("shell:openPath", path),
+  openExternal: (url) => ipcRenderer.invoke("shell:openExternal", url),
   openModelFile: () => ipcRenderer.invoke("dialog:openModelFile"),
   openModelFolder: () => ipcRenderer.invoke("dialog:openModelFolder"),
   listSyncConflicts: (folderPath) =>

--- a/frontend/src/features/Onboarding/Onboarding.tsx
+++ b/frontend/src/features/Onboarding/Onboarding.tsx
@@ -183,7 +183,10 @@ const Onboarding: FC<OnboardingProps> = ({
 
   const openSystemPreferences = () => {
     if (!systemPreferencesUrl) return;
-    void window.open(systemPreferencesUrl, "_blank");
+    // `window.open` is silently blocked by the main-process
+    // `setWindowOpenHandler`, which only forwards http(s) URLs. Route
+    // `x-apple.systempreferences:…` through the explicit bridge instead.
+    void window.mozgoslav.openExternal(systemPreferencesUrl);
   };
 
   const tryOnSample = async (): Promise<void> => {

--- a/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/DictationHelper.swift
+++ b/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/DictationHelper.swift
@@ -12,6 +12,11 @@ public final class DictationHelper {
     private let textInjector: TextInjectionService
     private let focusDetector: FocusedAppDetector
     private let hotkeyMonitor: HotkeyMonitor
+    // Serial queue for every stdout write. The JSON-RPC loop runs on a
+    // background thread (see main.swift) while HotkeyMonitor emits events
+    // from AppKit's main thread — without serialisation the two can
+    // interleave mid-line and corrupt the protocol.
+    private let writeQueue = DispatchQueue(label: "mozgoslav.helper.stdout")
 
     public init(
         stdin: FileHandle = .standardInput,
@@ -196,14 +201,16 @@ public final class DictationHelper {
     }
 
     private func respond(_ response: JsonRpcResponse) {
-        do {
-            let line = try JsonRpcCodec.encode(response) + "\n"
-            if let data = line.data(using: .utf8) {
-                stdout.write(data)
+        writeQueue.async { [self] in
+            do {
+                let line = try JsonRpcCodec.encode(response) + "\n"
+                if let data = line.data(using: .utf8) {
+                    stdout.write(data)
+                }
+            } catch {
+                // Best effort — if encoding fails we cannot signal the error
+                // back via the same channel; swallow and keep the loop alive.
             }
-        } catch {
-            // Best effort — if encoding fails we cannot signal the error
-            // back via the same channel; swallow and keep the loop alive.
         }
     }
 

--- a/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/main.swift
+++ b/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/main.swift
@@ -1,18 +1,47 @@
 import Foundation
 import DictationHelperCore
 
+#if canImport(AppKit) && os(macOS)
+import AppKit
+#endif
+
 // Entry point for the Mozgoslav dictation helper. The Electron main process
 // spawns this binary and talks to it over stdin/stdout using line-delimited
 // JSON-RPC messages. One process per user session; the helper exits cleanly
 // when stdin closes (Electron quit) or on an explicit "shutdown" request.
 //
-// Methods exposed:
-//   - capture.start {deviceId?, sampleRate}  → start mic capture, emit 16 kHz
-//     PCM chunks as "audio" events on stdout.
-//   - capture.stop                           → stop mic capture.
-//   - inject.text {text, mode}               → inject text into the focused app.
-//   - inject.detectTarget                    → returns {bundleId, useAX} for the
-//     currently focused app.
-//   - shutdown                               → clean exit.
+// IMPORTANT — AppKit run loop
+// `NSEvent.addGlobalMonitorForEvents` (used by HotkeyMonitor) and
+// `AXIsProcessTrustedWithOptions` (used by PermissionProbe) both require a
+// live AppKit run loop on the main thread. A bare CLI tool that just spins
+// on `stdin.readLine()` never delivers events to the observer and suppresses
+// the Accessibility prompt — observed symptom was "helper spawned, hotkey
+// silently dead, no macOS prompt". See Swift Forums thread
+// https://forums.swift.org/t/keeping-command-line-tool-alive-and-still-get-mouse-and-keyboard-events/48648
+// for the canonical diagnosis.
+//
+// Fix: drive the JSON-RPC loop on a background dispatch queue and let the
+// main thread pump `NSApplication.shared.run()`. `.accessory` activation
+// policy keeps the helper out of the Dock/menu bar — the user only sees the
+// Electron app itself.
 let helper = DictationHelper()
+
+#if canImport(AppKit) && os(macOS)
+DispatchQueue.global(qos: .userInitiated).async {
+    helper.run()
+    // stdin closed → ask the AppKit run loop to tear down so the process
+    // can exit cleanly. `terminate(_:)` dispatches back to the main thread.
+    DispatchQueue.main.async {
+        NSApplication.shared.terminate(nil)
+    }
+}
+
+let app = NSApplication.shared
+app.setActivationPolicy(.accessory)
+app.run()
+#else
+// Non-macOS builds (CI on Linux) have no AppKit and no global event
+// monitors to serve — fall back to the blocking stdin loop so the Swift
+// package still compiles and the JSON-RPC surface can be unit-tested.
 helper.run()
+#endif


### PR DESCRIPTION
## Why

After PR #18 the Accessibility prompt still didn't appear and the hotkey stayed silently dead. Root causes found:

### 1. Helper ran without an AppKit run loop

`main.swift` was `helper.run()` directly from the main thread, spinning on `stdin.readLine()`. Per Apple + Swift Forums docs (https://forums.swift.org/t/keeping-command-line-tool-alive-and-still-get-mouse-and-keyboard-events/48648) both `NSEvent.addGlobalMonitorForEvents` and `AXIsProcessTrustedWithOptions` require `NSApplication.shared.run()` — without it the global observer attaches a no-op and the macOS Accessibility prompt is suppressed, regardless of signing status.

Fix: drive the JSON-RPC loop on a background dispatch queue, pump `NSApplication.shared.run()` on main with `.accessory` activation policy so the helper stays invisible in Dock/menu bar. Non-macOS builds (Linux CI) keep the blocking `helper.run()` fallback.

### 2. Onboarding "Open System Preferences" button was a no-op

The click called `window.open(\"x-apple.systempreferences:…\")`, but `setWindowOpenHandler` in `main.ts` only forwards http(s) URLs — the rest is silently denied, matching the symptom "кнопка на онбординге при нажатии ничего не делает". Tied to permission cards (mic / dictation).

Fix: add `window.mozgoslav.openExternal(url)` bridge → `shell:openExternal` IPC → `shell.openExternal`, with a scheme whitelist (`http`, `https`, `mailto`, `x-apple.systempreferences`) so renderer-origin URLs cannot reach arbitrary OS handlers.

### 3. Window close left the .NET backend + Swift helper running

`app.on(\"window-all-closed\")` early-returned on darwin per standard AppKit semantics, but the user flow is ⌘W / red X = "I'm done". Backend + helper stayed resident, next launch collided with the port already in use. Override to `app.quit()` unconditionally so `before-quit` teardown runs.

## Files

- `helpers/…/main.swift` — background dispatch queue + `NSApplication.shared.run()` with `.accessory` policy.
- `helpers/…/DictationHelper.swift` — serial `writeQueue` for stdout so stdin-reader (bg thread) and AppKit emit callbacks (main thread) can't interleave mid-line.
- `frontend/electron/preload.ts` — `openExternal(url)` bridge + JSDoc.
- `frontend/electron/main.ts` — `shell:openExternal` handler with scheme whitelist + quit on window-all-closed on every platform.
- `frontend/src/features/Onboarding/Onboarding.tsx` — swap `window.open` → `window.mozgoslav.openExternal`.

## Test plan

- [ ] `cd helpers/MozgoslavDictationHelper && swift build -c release` — no warnings.
- [ ] Kill stale helpers: `pkill -f mozgoslav-dictation-helper`.
- [ ] `bash scripts/demo.command` on macOS 13+.
- [ ] On first hotkey press after fresh install the macOS Accessibility prompt appears. Grant, restart app, verify `helper-*.log` shows `accessibilityGranted=true` and `press`/`release` events fire.
- [ ] Onboarding → Mic / Dictation step → "Open System Preferences" button opens the correct Privacy pane.
- [ ] Close main window (red X). Verify `ps aux | grep -E 'Mozgoslav|dotnet|mozgoslav-dictation-helper'` shows no leftovers.

## Known limits

- AX trust is cached per-PID — after user grants permission the app must be relaunched for monitors to actually fire. This is a macOS constraint, not something the patch removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)