### PR TITLE
fix: Accessibility via parent Electron (TCC inheritance) + backend DI ambiguity

### DIFF
--- a/backend/src/Mozgoslav.Infrastructure/Services/AVFoundationAudioRecorder.cs
+++ b/backend/src/Mozgoslav.Infrastructure/Services/AVFoundationAudioRecorder.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -32,6 +33,13 @@ public sealed class AVFoundationAudioRecorder : IAudioRecorder
     private string? _activeSessionId;
     private DateTime _startedAtUtc;
 
+    // Typed HttpClient factory needs a single unambiguous ctor accepting
+    // HttpClient; the test-only overload below had the same argument shape
+    // and made `ActivatorUtilities.CreateFactory` throw
+    // `Multiple constructors accepting all given argument types have been
+    // found` on every `/api/audio/capabilities` call. `ActivatorUtilitiesConstructor`
+    // disambiguates for both the TypedHttpClientFactory and plain DI paths.
+    [ActivatorUtilitiesConstructor]
     public AVFoundationAudioRecorder(
         HttpClient http,
         ILogger<AVFoundationAudioRecorder> logger,

--- a/frontend/electron/main.ts
+++ b/frontend/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, ipcMain, session, shell } from "electron";
+import { app, BrowserWindow, dialog, ipcMain, session, shell, systemPreferences } from "electron";
 import path from "node:path";
 import { existsSync, promises as fs } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -172,6 +172,13 @@ app.whenReady().then(async () => {
   // (appsettings key: Mozgoslav:AudioRecorder:ElectronBridgePort).
   const recorderEnv: Record<string, string> = {};
   if (process.platform === "darwin") {
+    // macOS TCC is parent-process scoped: Accessibility is granted to the
+    // Electron.app (dev) or Mozgoslav.app (packaged) — spawned children
+    // inherit trust on macOS 13+. Trigger the native prompt here, BEFORE we
+    // spawn the Swift helper, so `NSEvent.addGlobalMonitorForEvents` inside
+    // the helper starts receiving events on the first successful grant.
+    // `isTrustedAccessibilityClient(true)` both probes and prompts.
+    ensureParentAccessibility();
     try {
         const helperBinaryPath = resolveDictationHelperPath();
       recordingHelper = new NativeHelperClient(helperBinaryPath);
@@ -213,6 +220,29 @@ app.whenReady().then(async () => {
   ipcMain.handle("shell:openPath", async (_, targetPath: string) => {
     const error = await shell.openPath(targetPath);
     return error || undefined;
+  });
+
+  // Accessibility trust lives on the parent Electron process — renderer
+  // surfaces (Onboarding, Settings) drive the prompt via these channels.
+  // `prompt=true` variant triggers the native macOS dialog; the read-only
+  // variant is safe for polling UI state without side-effects.
+  ipcMain.handle("permissions:isAccessibilityTrusted", async () => {
+    if (process.platform !== "darwin") return true;
+    return systemPreferences.isTrustedAccessibilityClient(false);
+  });
+
+  ipcMain.handle("permissions:requestAccessibility", async () => {
+    if (process.platform !== "darwin") return true;
+    const trusted = systemPreferences.isTrustedAccessibilityClient(true);
+    if (!trusted) {
+      // macOS suppresses the prompt once the user has denied (or dismissed)
+      // it, so we also deeplink them into the right Settings pane — at least
+      // the path to grant is one click away either way.
+      void shell.openExternal(
+        "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
+      );
+    }
+    return trusted;
   });
 
   // Onboarding permission cards need to deeplink into System Settings
@@ -393,6 +423,27 @@ const forwardHotkeyToBackend = async (payload: {
   } catch (err) {
     console.warn("[hotkey] failed to forward helper event to backend:", err);
   }
+};
+
+/**
+ * Probe + prompt Accessibility on the Electron parent process. macOS 13+
+ * TCC inheritance means a trusted parent lets its spawned children (the
+ * Swift helper we use for `NSEvent.addGlobalMonitorForEvents`) see input
+ * events without a separate System Settings entry. Returns the current
+ * trust state after the prompt call — callers usually don't read it,
+ * they just want the side-effect of showing the dialog once.
+ */
+const ensureParentAccessibility = (): boolean => {
+  if (process.platform !== "darwin") return true;
+  const trusted = systemPreferences.isTrustedAccessibilityClient(true);
+  if (!trusted) {
+    console.warn(
+      "[permissions] Accessibility not granted to the Electron parent. " +
+        "Hotkey monitor in the Swift helper will not receive events until " +
+        "the user grants access in System Settings → Privacy → Accessibility.",
+    );
+  }
+  return trusted;
 };
 
 const initializeDictation = async (): Promise<void> => {

--- a/frontend/electron/preload.ts
+++ b/frontend/electron/preload.ts
@@ -20,6 +20,18 @@ export interface MozgoslavBridge {
    * blocked by the hardened `setWindowOpenHandler` that only allows http(s).
    */
   openExternal: (url: string) => Promise<boolean>;
+  /**
+   * Read-only probe of Accessibility trust on the Electron parent process.
+   * Returns true outside macOS — renderer UIs should treat that as "n/a".
+   */
+  isAccessibilityTrusted: () => Promise<boolean>;
+  /**
+   * Trigger the native macOS Accessibility prompt on the Electron parent
+   * process (macOS 13+ children inherit the grant). If the prompt was
+   * suppressed by a prior denial, also deeplinks the user into System
+   * Settings → Privacy → Accessibility. Returns the post-call trust state.
+   */
+  requestAccessibility: () => Promise<boolean>;
   openModelFile: () => Promise<{ canceled: boolean; filePaths: string[] }>;
   openModelFolder: () => Promise<{ canceled: boolean; filePaths: string[] }>;
   listSyncConflicts: (
@@ -61,6 +73,8 @@ const bridge: MozgoslavBridge = {
   openFolder: () => ipcRenderer.invoke("dialog:openFolder"),
   openPath: (path) => ipcRenderer.invoke("shell:openPath", path),
   openExternal: (url) => ipcRenderer.invoke("shell:openExternal", url),
+  isAccessibilityTrusted: () => ipcRenderer.invoke("permissions:isAccessibilityTrusted"),
+  requestAccessibility: () => ipcRenderer.invoke("permissions:requestAccessibility"),
   openModelFile: () => ipcRenderer.invoke("dialog:openModelFile"),
   openModelFolder: () => ipcRenderer.invoke("dialog:openModelFolder"),
   listSyncConflicts: (folderPath) =>

--- a/frontend/src/features/Onboarding/Onboarding.tsx
+++ b/frontend/src/features/Onboarding/Onboarding.tsx
@@ -182,10 +182,20 @@ const Onboarding: FC<OnboardingProps> = ({
   const permissionTestId = PERMISSION_TEST_ID[currentStep];
 
   const openSystemPreferences = () => {
+    // Dictation card: trigger the macOS Accessibility prompt on the
+    // Electron parent process. Spawned children (our Swift helper) inherit
+    // the grant on macOS 13+, so this is the only path that actually wires
+    // up the global hotkey — an unbundled CLI helper cannot request TCC on
+    // its own. If the user has already denied, the bridge falls back to
+    // deeplinking the Accessibility pane so grant is still one click away.
+    if (currentStep === "dictation") {
+      void window.mozgoslav.requestAccessibility();
+      return;
+    }
+    // Mic card and any future permission card: plain deeplink. `window.open`
+    // is silently blocked by the main-process `setWindowOpenHandler`, which
+    // only forwards http(s) — route x-apple.systempreferences:… via IPC.
     if (!systemPreferencesUrl) return;
-    // `window.open` is silently blocked by the main-process
-    // `setWindowOpenHandler`, which only forwards http(s) URLs. Route
-    // `x-apple.systempreferences:…` through the explicit bridge instead.
     void window.mozgoslav.openExternal(systemPreferencesUrl);
   };
 

--- a/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/HotkeyMonitor.swift
+++ b/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/HotkeyMonitor.swift
@@ -29,7 +29,6 @@ public final class HotkeyMonitor {
     private let isoFormatter: ISO8601DateFormatter
     private var parsed: ParsedAccelerator?
     private var holding: Bool = false
-    private var didRequestPermissionsOnce: Bool = false
 
     #if canImport(AppKit) && os(macOS)
     private var keyDownMonitor: Any?
@@ -56,24 +55,20 @@ public final class HotkeyMonitor {
         self.parsed = parsed
 
         #if canImport(AppKit) && os(macOS)
-        // `NSEvent.addGlobalMonitorForEvents` silently returns a no-op
-        // observer when the helper process lacks Accessibility (and often
-        // Input Monitoring). On the first `start` per process we trigger
-        // the native macOS prompts — that educates first-run users and
-        // makes the underlying failure mode visible in the FileLog.
-        // Subsequent starts re-check without re-opening Settings, so we
-        // don't nag after every settings save.
+        // Accessibility is a **parent-process** concern: macOS TCC tracks
+        // trust per app bundle. This helper is an unbundled CLI binary, so
+        // calling `AXIsProcessTrustedWithOptions(prompt:)` from here does
+        // nothing useful — the prompt never appears and no entry is created
+        // in System Settings. Trust comes from the Electron parent (which
+        // has a bundle identity); spawned children inherit its TCC on
+        // macOS 13+. We log current state for diagnostics, nothing else.
+        // See Electron main — `systemPreferences.isTrustedAccessibilityClient`.
         let accessibilityGranted = PermissionProbe.accessibilityStatus() == "granted"
-        if !didRequestPermissionsOnce {
-            didRequestPermissionsOnce = true
-            _ = PermissionProbe.requestAccessibility()
-            _ = PermissionProbe.requestInputMonitoring()
-            if !accessibilityGranted {
-                FileLog.shared.warn(
-                    "H1 HotkeyMonitor: Accessibility not granted — opening System Settings"
-                )
-                PermissionProbe.openAccessibilitySettings()
-            }
+        if !accessibilityGranted {
+            FileLog.shared.warn(
+                "H1 HotkeyMonitor: Accessibility not inherited — parent Electron.app " +
+                "is missing TCC approval; hotkey monitor will receive no events."
+            )
         }
 
         keyDownMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in


### PR DESCRIPTION
## Where I was wrong

In PRs #18/#19 I proposed that the Swift `mozgoslav-dictation-helper` binary itself request Accessibility and be added to System Settings. That was the wrong mental model — explains why the prompt never fired and why `dictation-helper не существует` in the list.

macOS TCC is parent-process scoped: trust is granted to an app bundle identity, and on macOS 13+ **spawned children inherit the grant** (reference: [Wojciech Regula — ELECTRONizing macOS privacy](https://wojciechregula.blog/post/electroniz3r/)). Our helper is an unbundled CLI executable with no Info.plist, so:

- `AXIsProcessTrustedWithOptions(prompt:)` from the helper does nothing — macOS suppresses the dialog for unbundled binaries regardless of run loop or signing state.
- `mozgoslav-dictation-helper` cannot appear as a separate entry in System Settings → Accessibility.
- The correct path is to prompt on the Electron **parent** (Electron.app in dev / Mozgoslav.app in packaged). The Swift child process inherits trust automatically and `NSEvent.addGlobalMonitorForEvents` starts firing.

## Changes

- `frontend/electron/main.ts`:
  - `ensureParentAccessibility()` wraps Electron's `systemPreferences.isTrustedAccessibilityClient(true)` — probes + prompts the parent, called **before** we spawn the Swift helper.
  - `permissions:isAccessibilityTrusted` and `permissions:requestAccessibility` IPC channels. Request handler also deeplinks System Settings when the prompt is suppressed (user previously denied).
- `frontend/electron/preload.ts`: bridge methods `isAccessibilityTrusted()` / `requestAccessibility()`.
- `frontend/src/features/Onboarding/Onboarding.tsx`: dictation card's CTA calls `requestAccessibility()` so the native prompt fires on the parent. Mic card keeps the plain deeplink.
- `helpers/…/HotkeyMonitor.swift`: remove helper-side `requestAccessibility()` / `openAccessibilitySettings()` calls — they had no effect from an unbundled child. Keep diagnostic logging: `Accessibility not inherited` now tells the maintainer exactly which layer is missing TCC.

## Bundled fix: backend 500 on `/api/audio/capabilities`

`AVFoundationAudioRecorder` declared two public constructors both accepting `HttpClient` (production + test overload). `TypedHttpClientFactory` uses `ActivatorUtilities.CreateFactory` which rejects ambiguous matches, throwing `Multiple constructors accepting all given argument types have been found` on every request. Annotated the production ctor with `[ActivatorUtilitiesConstructor]`.

## Where the user sees the permission

| Build       | Entry in System Settings → Accessibility                     |
|-------------|--------------------------------------------------------------|
| `npm run dev` | `Electron` (path: `node_modules/electron/.../Electron.app`) |
| Packaged DMG | `Mozgoslav`                                                 |

`mozgoslav-dictation-helper` must **not** appear — it inherits from the parent. This resolves the earlier confusion.

## Test plan

- [ ] macOS: close app → `pkill -f mozgoslav-dictation-helper` → start fresh.
- [ ] First launch surfaces the native Accessibility prompt for Electron/Mozgoslav. Grant, relaunch.
- [ ] Press hotkey → `helper-*.log` no longer shows `Accessibility not inherited`, and `press`/`release` events flow.
- [ ] Onboarding → Dictation card → "Open System Preferences" button triggers the native prompt (not just a deeplink).
- [ ] `curl localhost:5050/api/audio/capabilities` returns 200 (DI ambiguity resolved).

## Limits

AX trust is cached per-PID. After the user grants permission the app must be relaunched for the Swift helper to actually start receiving events. This is a macOS constraint; we surface the state in `helper-*.log` so it's at least observable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)