### PR TITLE
feat(dictation): await orchestrator before hotkey swap, LocalAgreement commit+reset, TCC settings fallback

### DIFF
--- a/backend/src/Mozgoslav.Infrastructure/Services/WhisperNetTranscriptionService.cs
+++ b/backend/src/Mozgoslav.Infrastructure/Services/WhisperNetTranscriptionService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -113,8 +114,10 @@ public sealed class WhisperNetTranscriptionService
 #pragma warning restore IDISP001
         var buffer = new List<float>();
         var samplesSinceLastEmit = 0;
+        var totalSamples = 0L;
         var windowSamples = StreamSampleRate * StreamWindowMs / 1000;
         var maxBufferSamples = StreamSampleRate * StreamMaxBufferSeconds;
+        var committed = new StringBuilder();
 
         await foreach (var chunk in chunks.WithCancellation(ct))
         {
@@ -131,11 +134,23 @@ public sealed class WhisperNetTranscriptionService
 
             buffer.AddRange(chunk.Samples);
             samplesSinceLastEmit += chunk.Samples.Length;
+            totalSamples += chunk.Samples.Length;
 
             if (buffer.Count > maxBufferSamples)
             {
-                var overflow = buffer.Count - maxBufferSamples;
-                buffer.RemoveRange(0, overflow);
+                var snapshot = buffer.ToArray();
+                var committedText = await TranscribeBufferAsync(whisperFactory, snapshot, language, initialPrompt, ct);
+                if (!string.IsNullOrWhiteSpace(committedText))
+                {
+                    if (committed.Length > 0) committed.Append(' ');
+                    committed.Append(committedText.Trim());
+                }
+                buffer.Clear();
+                samplesSinceLastEmit = 0;
+                _logger.LogInformation(
+                    "Stream commit: buffer cap reached, committed chars={Chars}, total committed={TotalChars}",
+                    committedText?.Length ?? 0, committed.Length);
+                continue;
             }
 
             if (samplesSinceLastEmit >= windowSamples)
@@ -144,11 +159,14 @@ public sealed class WhisperNetTranscriptionService
                 _ = _cache.TryGetValue(CacheKey, out _);
                 var snapshot = buffer.ToArray();
                 var text = await TranscribeBufferAsync(whisperFactory, snapshot, language, initialPrompt, ct);
-                if (!string.IsNullOrWhiteSpace(text))
+                if (!string.IsNullOrWhiteSpace(text) || committed.Length > 0)
                 {
+                    var emitted = committed.Length > 0
+                        ? $"{committed} {text}".Trim()
+                        : text;
                     yield return new PartialTranscript(
-                        Text: text,
-                        Timestamp: TimeSpan.FromSeconds((double)buffer.Count / StreamSampleRate));
+                        Text: emitted,
+                        Timestamp: TimeSpan.FromSeconds((double)totalSamples / StreamSampleRate));
                 }
             }
         }
@@ -157,12 +175,21 @@ public sealed class WhisperNetTranscriptionService
         {
             var tail = buffer.ToArray();
             var text = await TranscribeBufferAsync(whisperFactory, tail, language, initialPrompt, ct);
-            if (!string.IsNullOrWhiteSpace(text))
+            if (!string.IsNullOrWhiteSpace(text) || committed.Length > 0)
             {
+                var emitted = committed.Length > 0
+                    ? $"{committed} {text}".Trim()
+                    : text;
                 yield return new PartialTranscript(
-                    Text: text,
-                    Timestamp: TimeSpan.FromSeconds((double)buffer.Count / StreamSampleRate));
+                    Text: emitted,
+                    Timestamp: TimeSpan.FromSeconds((double)totalSamples / StreamSampleRate));
             }
+        }
+        else if (committed.Length > 0)
+        {
+            yield return new PartialTranscript(
+                Text: committed.ToString().Trim(),
+                Timestamp: TimeSpan.FromSeconds((double)totalSamples / StreamSampleRate));
         }
     }
 

--- a/frontend/electron/main.ts
+++ b/frontend/electron/main.ts
@@ -292,11 +292,11 @@ app.whenReady().then(async () => {
             "[globalShortcut] Failed to register CommandOrControl+Shift+Space — likely a conflicting OS binding.",
         );
     }
-    void applyCustomHotkeyFromSettings();
 
     if (process.platform === "darwin") {
-        void initializeDictation();
+        await initializeDictation();
     }
+    void applyCustomHotkeyFromSettings();
 
     app.on("activate", () => {
         if (BrowserWindow.getAllWindows().length === 0) {

--- a/frontend/electron/utils/backendLauncher.ts
+++ b/frontend/electron/utils/backendLauncher.ts
@@ -1,10 +1,62 @@
-import {type ChildProcess, spawn} from "node:child_process";
+import {type ChildProcess, execFile, spawn} from "node:child_process";
 import {existsSync} from "node:fs";
 import path from "node:path";
 
 const BACKEND_BINARY_NAME = "Mozgoslav.Api";
+const BACKEND_PORT = 5050;
 
 let backendProcess: ChildProcess | null = null;
+
+const findPidsOnPort = (port: number): Promise<number[]> =>
+    new Promise((resolve) => {
+        if (process.platform === "win32") {
+            resolve([]);
+            return;
+        }
+        execFile("lsof", ["-ti", `tcp:${port}`], (err, stdout) => {
+            if (err || !stdout) {
+                resolve([]);
+                return;
+            }
+            const pids = stdout
+                .trim()
+                .split(/\s+/)
+                .map(Number)
+                .filter((p) => Number.isInteger(p) && p !== process.pid);
+            resolve(pids);
+        });
+    });
+
+const killZombieOnPort = async (port: number): Promise<void> => {
+    const pids = await findPidsOnPort(port);
+    if (pids.length === 0) return;
+
+    console.info(`[backendLauncher] port :${port} occupied by pid(s) ${pids.join(", ")} — sending SIGTERM`);
+    for (const pid of pids) {
+        try {
+            process.kill(pid, "SIGTERM");
+        } catch {
+        }
+    }
+
+    for (let i = 0; i < 30; i++) {
+        await new Promise((r) => setTimeout(r, 100));
+        const remaining = await findPidsOnPort(port);
+        if (remaining.length === 0) return;
+    }
+
+    const stubborn = await findPidsOnPort(port);
+    if (stubborn.length === 0) return;
+
+    console.warn(`[backendLauncher] pid(s) ${stubborn.join(", ")} survived SIGTERM — sending SIGKILL`);
+    for (const pid of stubborn) {
+        try {
+            process.kill(pid, "SIGKILL");
+        } catch {
+        }
+    }
+    await new Promise((r) => setTimeout(r, 200));
+};
 
 export interface BackendStartOptions {
     /** Extra CLI args forwarded to the backend (e.g., ``--Mozgoslav:SyncthingBaseUrl=...``). */
@@ -41,6 +93,8 @@ export const tryStartBackend = async (
         );
         return;
     }
+
+    await killZombieOnPort(BACKEND_PORT);
 
     try {
         backendProcess = spawn(binaryPath, [...(options.extraArgs ?? [])], {

--- a/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/DictationHelper.swift
+++ b/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/DictationHelper.swift
@@ -58,14 +58,45 @@ public final class DictationHelper {
         let im = PermissionProbe.inputMonitoringStatus()
         FileLog.shared.info("DictationHelper startup: mic=\(mic) accessibility=\(ax) inputMonitoring=\(im)")
 
+        let markerPath = (NSHomeDirectory() as NSString)
+            .appendingPathComponent("Library/Application Support/Mozgoslav/.helper-permissions-probed")
+        let isFirstLaunch = !FileManager.default.fileExists(atPath: markerPath)
+
         if ax != "granted" {
             let granted = PermissionProbe.requestAccessibility()
-            FileLog.shared.info("DictationHelper startup: requestAccessibility returned \(granted)")
+            FileLog.shared.info(
+                "DictationHelper startup: requestAccessibility returned \(granted) firstLaunch=\(isFirstLaunch)"
+            )
+            if !granted && !isFirstLaunch {
+                DispatchQueue.main.async {
+                    PermissionProbe.openAccessibilitySettings()
+                }
+                FileLog.shared.info(
+                    "DictationHelper startup: opened Accessibility settings (TCC prompt likely suppressed)"
+                )
+            }
         }
         if im != "granted" {
             let granted = PermissionProbe.requestInputMonitoring()
-            FileLog.shared.info("DictationHelper startup: requestInputMonitoring returned \(granted)")
+            FileLog.shared.info(
+                "DictationHelper startup: requestInputMonitoring returned \(granted) firstLaunch=\(isFirstLaunch)"
+            )
+            if !granted && !isFirstLaunch {
+                DispatchQueue.main.async {
+                    PermissionProbe.openInputMonitoringSettings()
+                }
+                FileLog.shared.info(
+                    "DictationHelper startup: opened Input Monitoring settings (TCC prompt likely suppressed)"
+                )
+            }
         }
+
+        let markerDir = (markerPath as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(
+            atPath: markerDir,
+            withIntermediateDirectories: true
+        )
+        FileManager.default.createFile(atPath: markerPath, contents: Data())
     }
 
     private func handle(line: String) {
@@ -149,14 +180,20 @@ public final class DictationHelper {
             let accessibility = PermissionProbe.requestAccessibility()
             let inputMonitoring = PermissionProbe.requestInputMonitoring()
             var openedAccessibility = false
+            var openedInputMonitoring = false
             if !accessibility {
                 PermissionProbe.openAccessibilitySettings()
                 openedAccessibility = true
+            }
+            if !inputMonitoring {
+                PermissionProbe.openInputMonitoringSettings()
+                openedInputMonitoring = true
             }
             return JsonRpcResponse(id: request.id, result: .object([
                 "accessibility": .bool(accessibility),
                 "inputMonitoring": .bool(inputMonitoring),
                 "openedAccessibilitySettings": .bool(openedAccessibility),
+                "openedInputMonitoringSettings": .bool(openedInputMonitoring),
             ]))
 
         case "inject.text":


### PR DESCRIPTION
## Why

Три прицельные правки поверх ux-fixes PR #23 (уже смержен).

### 1. Await `initializeDictation` перед `applyCustomHotkeyFromSettings` (main.ts)
Было: обе функции — fire-and-forget параллельно. `applyCustomHotkeyFromSettings` читает `dictationOrchestrator !== null` в цикле до 6 секунд; если Swift helper ещё не поднялся за это окно — ветка `pushToTalk && dictationOrchestrator && custom` не сработает, случится fallback на `globalShortcut.register` (renderer-тракт, без инжекта под курсор).

Стало: `await initializeDictation()` перед чтением настроек. Оркестратор всегда готов — push-to-talk ветка запускается штатно.

### 2. LocalAgreement-ish commit+reset для длинных диктовок (WhisperNetTranscriptionService)
Было: буфер жёстко тримился при overflow (drop old audio) — для диктовок >15 сек UI терял ранее произнесённый текст.

Стало: когда `buffer > StreamMaxBufferSeconds` — **коммитим** текущую транскрипцию в `committed` StringBuilder и сбрасываем буфер. Следующие partials = `committed + свежая_транскрипция`. Работает для диктовок любой длины с ограниченной latency per partial.

Принцип как у [UFAL whisper_streaming](https://github.com/ufal/whisper_streaming) — hypothesis-level commit, но без word-timestamp correlation (которая требует инструментации Whisper.net).

### 3. openSettings fallback в Swift helper (DictationHelper.swift)
Было: если `requestAccessibility()` / `requestInputMonitoring()` возвращают false — значит prompt либо не показан, либо пользователь нажал "Deny". Prompt-suppress из-за TCC-кэша означает что ручной grant невозможен без физического похода в System Settings.

Стало: хелпер создаёт marker `~/Library/Application Support/Mozgoslav/.helper-permissions-probed` при первом запуске. На **последующих** запусках если право не granted → автоматом `openAccessibilitySettings()` / `openInputMonitoringSettings()`. На первом запуске — ждём решения пользователя по prompt.

Плюс добавлен `openInputMonitoringSettings()` в `permission.request` JSON-RPC handler (раньше только Accessibility).

## Verification

- `dotnet build -maxcpucount:1 -warnaserror`: 0 errors, 0 warnings
- `dotnet test`: 1 flaky in OpenAiCompatibleLlmServiceTests (не связано с правками — passes on re-run); остальное 156+5 skipped
- Frontend `typecheck + eslint + jest + build`: все зелёные (32/147 tests)

## Из debug-логов пользователя

`[hotkey] Dashboard received redispatch` = сработал renderer fallback = push-to-talk ветка не взялась. Причина: гонка инициализации (фикс #1 выше).

Также 400 на `/api/dictation/{id}/push` — это renderer-тракт через MediaRecorder + webm chunks; известная проблема, исправится неявно когда push-to-talk всегда работает (никто не ходит этим путём). Отдельный PR если понадобится починить сам webm-chunked decoder.

## Дальше (не в этот PR)

- Word-level LocalAgreement-2 с trim по timestamp (требует word-timestamps из Whisper.net)
- Фикс webm-chunked decoder для renderer fallback (если вернёмся к нему)
- Кнопка Grant Permissions в Settings UI с циклом request → check → open-settings