### PR TITLE
fix(dictation): SSE 500 on cancel, helper stderr logs, hotkey path diagnostics

### DIFF
--- a/backend/src/Mozgoslav.Infrastructure/Services/ChannelAudioDeviceChangeNotifier.cs
+++ b/backend/src/Mozgoslav.Infrastructure/Services/ChannelAudioDeviceChangeNotifier.cs
@@ -40,8 +40,21 @@ public sealed class ChannelAudioDeviceChangeNotifier : IAudioDeviceChangeNotifie
         _subscribers[id] = channel;
         try
         {
-            await foreach (var evt in channel.Reader.ReadAllAsync(ct))
+            while (true)
             {
+                AudioDeviceChangePayload evt;
+                try
+                {
+                    evt = await channel.Reader.ReadAsync(ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    yield break;
+                }
+                catch (ChannelClosedException)
+                {
+                    yield break;
+                }
                 yield return evt;
             }
         }

--- a/backend/src/Mozgoslav.Infrastructure/Services/ChannelHotkeyEventNotifier.cs
+++ b/backend/src/Mozgoslav.Infrastructure/Services/ChannelHotkeyEventNotifier.cs
@@ -41,8 +41,21 @@ public sealed class ChannelHotkeyEventNotifier : IHotkeyEventNotifier, IDisposab
         _subscribers[id] = channel;
         try
         {
-            await foreach (var evt in channel.Reader.ReadAllAsync(ct))
+            while (true)
             {
+                HotkeyEvent evt;
+                try
+                {
+                    evt = await channel.Reader.ReadAsync(ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    yield break;
+                }
+                catch (ChannelClosedException)
+                {
+                    yield break;
+                }
                 yield return evt;
             }
         }

--- a/backend/src/Mozgoslav.Infrastructure/Services/ChannelJobProgressNotifier.cs
+++ b/backend/src/Mozgoslav.Infrastructure/Services/ChannelJobProgressNotifier.cs
@@ -45,8 +45,21 @@ public sealed class ChannelJobProgressNotifier : IJobProgressNotifier, IDisposab
         _subscribers[id] = channel;
         try
         {
-            await foreach (var job in channel.Reader.ReadAllAsync(ct))
+            while (true)
             {
+                ProcessingJob job;
+                try
+                {
+                    job = await channel.Reader.ReadAsync(ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    yield break;
+                }
+                catch (ChannelClosedException)
+                {
+                    yield break;
+                }
                 yield return job;
             }
         }

--- a/frontend/electron/main.ts
+++ b/frontend/electron/main.ts
@@ -325,26 +325,34 @@ const applyCustomHotkeyFromSettings = async (): Promise<void> => {
             };
             const custom = settings.dictationKeyboardHotkey?.trim() ?? "";
             const pushToTalk = settings.dictationPushToTalk === true;
+            console.info("=".repeat(70));
             console.info(
-                `[hotkey] applyCustomHotkeyFromSettings: custom='${custom}' pushToTalk=${pushToTalk} orchestratorReady=${dictationOrchestrator !== null}`,
+                `[hotkey] CHECKPOINT settings.custom='${custom}' settings.pushToTalk=${pushToTalk} orchestratorReady=${dictationOrchestrator !== null}`,
             );
 
             if (pushToTalk && dictationOrchestrator && custom) {
+                console.info("[hotkey] PATH -> Swift helper push-to-talk (cursor injection enabled)");
                 unregisterGlobalDictationHotkey();
+                console.info("[hotkey]   unregistered Electron globalShortcut");
                 try {
                     dictationOrchestrator.onKeyboardHotkeyEvent((payload) => {
                         void forwardHotkeyToBackend(payload);
                     });
                     await dictationOrchestrator.startKeyboardHotkey(custom);
-                    console.log(`[hotkey] push-to-talk monitor started for '${custom}'.`);
+                    console.info(`[hotkey]   Swift helper monitor started for '${custom}' — check stderr for 'H1 HotkeyMonitor' lines`);
                 } catch (err) {
-                    console.warn("[hotkey] failed to start native monitor; falling back to globalShortcut toggle:", err);
+                    console.warn("[hotkey] Swift helper FAILED to start monitor:", err);
+                    console.warn("[hotkey] FALLBACK -> Electron globalShortcut toggle (NO cursor injection)");
                     registerGlobalDictationHotkey(custom);
                 }
                 return;
             }
 
-            if (!custom) return; // user hasn't set anything — keep default toggle.
+            if (!custom) {
+                console.info("[hotkey] PATH -> default Electron globalShortcut (no custom, toggle mode, no cursor injection)");
+                return;
+            }
+            console.info("[hotkey] PATH -> custom Electron globalShortcut (toggle mode, NO cursor injection)");
             unregisterGlobalDictationHotkey();
             const ok = registerGlobalDictationHotkey(custom);
             if (!ok) {

--- a/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/FileLog.swift
+++ b/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/FileLog.swift
@@ -37,11 +37,14 @@ public final class FileLog {
     private func append(level: String, message: String) {
         queue.async { [self] in
             let now = Date()
+            let line = "[\(isoFormatter.string(from: now))] [\(level)] \(message)\n"
+            if let data = line.data(using: .utf8) {
+                FileHandle.standardError.write(data)
+            }
             guard let logsDir = logsDirectory() else { return }
             let logFile = logsDir.appendingPathComponent(
                 "helper-\(dateFormatter.string(from: now)).log"
             )
-            let line = "[\(isoFormatter.string(from: now))] [\(level)] \(message)\n"
             try? FileManager.default.createDirectory(at: logsDir, withIntermediateDirectories: true)
             if let data = line.data(using: .utf8) {
                 if FileManager.default.fileExists(atPath: logFile.path) {

--- a/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/HotkeyMonitor.swift
+++ b/helpers/MozgoslavDictationHelper/Sources/MozgoslavDictationHelper/HotkeyMonitor.swift
@@ -58,8 +58,9 @@ public final class HotkeyMonitor {
         let accessibilityGranted = PermissionProbe.accessibilityStatus() == "granted"
         if !accessibilityGranted {
             FileLog.shared.warn(
-                "H1 HotkeyMonitor: Accessibility not inherited — parent Electron.app " +
-                "is missing TCC approval; hotkey monitor will receive no events."
+                "H1 HotkeyMonitor: Accessibility NOT granted — NSEvent.addGlobalMonitorForEvents " +
+                "will silently return nil; push-to-talk hotkey will NEVER fire. " +
+                "Grant in System Settings → Privacy & Security → Accessibility (Electron.app or Mozgoslav.app)."
             )
         }
 
@@ -73,8 +74,16 @@ public final class HotkeyMonitor {
             _ = event
             _ = self
         }
+        if keyDownMonitor == nil || keyUpMonitor == nil {
+            FileLog.shared.warn(
+                "H1 HotkeyMonitor: NSEvent.addGlobalMonitorForEvents returned nil " +
+                "(keyDown=\(keyDownMonitor != nil ? "ok" : "NIL") keyUp=\(keyUpMonitor != nil ? "ok" : "NIL")) — " +
+                "hotkey will not fire. Check Accessibility grant."
+            )
+        }
         FileLog.shared.info(
-            "H1 HotkeyMonitor started for accelerator='\(trimmed)' accessibilityGranted=\(accessibilityGranted)"
+            "H1 HotkeyMonitor started for accelerator='\(trimmed)' accessibilityGranted=\(accessibilityGranted) " +
+            "keyDownMonitor=\(keyDownMonitor != nil) keyUpMonitor=\(keyUpMonitor != nil)"
         )
         #else
         _ = parsed


### PR DESCRIPTION
## Context

После мерджа PR #24 в логах:
1. **Dictation ушла через renderer path** (POST `/api/dictation/{id}/push` × 6 успешно, `finalized 1 chars`, никакого инжекта под курсор) — значит push-to-talk не активировался, хотя в Settings он включён.
2. **500 на трёх SSE endpoint'ах** с `OperationCanceledException` — при client-disconnect.

## Fixes

### 1. SSE 500 → graceful cancel (3 файла)
`ChannelHotkeyEventNotifier`, `ChannelAudioDeviceChangeNotifier`, `ChannelJobProgressNotifier`.

Было: `await foreach (var x in channel.Reader.ReadAllAsync(ct))` — при cancellation OCE пробрасывается наверх → ASP.NET SSE → 500.

Стало: `while (true) { try { evt = await ReadAsync(ct); } catch (OCE or ChannelClosedException) { yield break; } yield return evt; }`. Клиент disconnect → тихое 200/завершение потока, логи чистые.

### 2. Swift helper logs → stderr (видно в Electron console)
`FileLog.append()` теперь дублирует в `FileHandle.standardError` параллельно с файлом. Electron ловит `child.stderr` → видно через `[dictation:helper:err]` в Electron console.

Раньше: все `H1 HotkeyMonitor: ...` / `TextInjectionService: ...` / `probeAndRequestPermissionsAtStartup` заметки жили только в `~/Library/Logs/Mozgoslav/helper-YYYYMMDD.log`. Теперь — сразу в консоли dev-сессии.

### 3. HotkeyMonitor — fail-loud при отсутствии Accessibility
Было: `NSEvent.addGlobalMonitorForEvents` при denied Accessibility возвращает `nil` **без ошибки**. `start()` логировал `accessibilityGranted=false` → и всё. Молчаливый провал.

Стало:
- Отдельное WARN если `keyDownMonitor == nil || keyUpMonitor == nil` с конкретикой какой именно nil
- В основной лог добавлены ok/NIL-статусы для каждого монитора

### 4. `applyCustomHotkeyFromSettings` — явный выбор path в логе
Чтобы в следующий раз сразу видеть, что именно выполнилось:
```
======================================================================
[hotkey] CHECKPOINT settings.custom='cmd+6' settings.pushToTalk=true orchestratorReady=true
[hotkey] PATH -> Swift helper push-to-talk (cursor injection enabled)
[hotkey]   unregistered Electron globalShortcut
[hotkey]   Swift helper monitor started for 'cmd+6' — check stderr for 'H1 HotkeyMonitor' lines
```

Или при fallback:
```
[hotkey] Swift helper FAILED to start monitor: <error>
[hotkey] FALLBACK -> Electron globalShortcut toggle (NO cursor injection)
```

Или когда pushToTalk=true в UI но где-то не выполняется условие:
```
[hotkey] PATH -> custom Electron globalShortcut (toggle mode, NO cursor injection)
```

Прямо в консоли видно, почему произошло что произошло.

## Verification
- `dotnet build -maxcpucount:1 -warnaserror`: 0 errors, 0 warnings
- `dotnet test`: 360 passed / 10 skipped, 0 failed
- Frontend `typecheck + eslint + jest`: 32/147 tests green

## Запусти у себя и скинь новые логи

После `npm run dev` + триггера хоткея — в консоли будет блок `======` с CHECKPOINT. Оттуда сразу поймём:
1. какой path взят (Swift helper или fallback),
2. если Swift — статусы `keyDownMonitor=true/false` из helper stderr,
3. если TCC мешает — лог `Accessibility NOT granted` с инструкцией.