### PR TITLE
fix(scripts): require Python ≥3.11 in demo.command bootstrap

### DIFF
--- a/scripts/demo.command
+++ b/scripts/demo.command
@@ -33,14 +33,33 @@ VENV_DIR="$SIDECAR_DIR/.venv"
 REQ_FILE="$SIDECAR_DIR/requirements.txt"
 REQ_HASH_FILE="$VENV_DIR/.requirements.sha256"
 
-PY_BIN="$(command -v python3.11 || command -v python3 || true)"
+py_at_least_311() {
+  "$1" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null
+}
+
+PY_BIN=""
+for candidate in python3.11 python3.12 python3.13 python3; do
+  bin="$(command -v "$candidate" 2>/dev/null || true)"
+  if [ -n "$bin" ] && py_at_least_311 "$bin"; then
+    PY_BIN="$bin"
+    break
+  fi
+done
 if [ -z "$PY_BIN" ]; then
-  echo "✗ python3.11 / python3 not found in PATH" >&2
+  echo "✗ Python ≥3.11 not found in PATH (python-sidecar requires it; numpy>=2.2.0)" >&2
+  echo "  install: brew install python@3.11" >&2
+  echo "  or: pyenv install 3.11" >&2
   exit 1
 fi
 
+# Stale venv built by older python — recreate
+if [ -f "$VENV_DIR/bin/python" ] && ! py_at_least_311 "$VENV_DIR/bin/python"; then
+  echo "→ existing $VENV_DIR uses Python <3.11, recreating..."
+  rm -rf "$VENV_DIR"
+fi
+
 if [ ! -f "$VENV_DIR/bin/activate" ]; then
-  echo "→ creating python-sidecar venv ($PY_BIN)..."
+  echo "→ creating python-sidecar venv (using $PY_BIN)..."
   "$PY_BIN" -m venv "$VENV_DIR"
 fi
 


### PR DESCRIPTION
> Stacked on top of #26 — base branch is `rybalchenko/demo-command-auto-bootstrap-2026-04-19`, not `main`. Merge order: #26 first, then this.

## Problem
После #26 `scripts/demo.command` падал на установке зависимостей:
```
ERROR: Could not find a version that satisfies the requirement numpy>=2.2.0
ERROR: No matching distribution found for numpy>=2.2.0
```
Корень: фолбэк `python3.11 || python3` подхватывал системный macOS Python 3.9 (там нет `python3.11` в PATH), а `numpy>=2.2.0` требует ≥3.11. Каскад: десятки пакетов из `requirements.txt` отбрасываются по `Requires-Python`, install ломается.

## Fix
- Перебираем `python3.11 / 3.12 / 3.13 / python3`, берём первый рантайм с `sys.version_info >= (3, 11)`.
- Если ничего не подошло — падаем громко с подсказкой `brew install python@3.11` / `pyenv install 3.11`.
- Если в `python-sidecar/.venv` уже лежит venv, собранный старым питоном — удаляем и пересобираем.

## Test plan
- [x] `bash -n scripts/demo.command` — синтаксис чистый.
- [x] Helper `py_at_least_311` отдельно прогнан на Python 3.12.3 (`PASS`).
- [ ] Реальный double-click на macOS с поставленным `python@3.11` — за тобой.

## Local fix для уже сломанного venv
```bash
brew install python@3.11
cd python-sidecar && rm -rf .venv
python3.11 -m venv .venv
source .venv/bin/activate && pip install --upgrade pip && pip install -r requirements.txt
shasum -a 256 requirements.txt | awk '{print $1}' > .venv/.requirements.sha256
deactivate
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)