### PR TITLE
fix(scripts): align demo.command sidecar port to 5060

### DIFF
--- a/scripts/demo.command
+++ b/scripts/demo.command
@@ -112,7 +112,7 @@ done
 
 # Python sidecar
 echo "→ starting python-sidecar..."
-(cd python-sidecar && source .venv/bin/activate && uvicorn app.main:app --host 127.0.0.1 --port 5051) &
+(cd python-sidecar && source .venv/bin/activate && uvicorn app.main:app --host 127.0.0.1 --port 5060) &
 SIDECAR_PID=$!
 
 # Frontend (foreground — window blocks until user quits)


### PR DESCRIPTION
## Problem
Загруженная запись зависала на этапе транскрибации с каскадом ошибок в backend-логах:
```
System.Net.Http.HttpRequestException: Connection refused (127.0.0.1:5060)
[WRN] Python sidecar /embed failed; falling back to bag-of-words for this call
   at Mozgoslav.Infrastructure.Rag.PythonSidecarEmbeddingService.EmbedAsync(...)
```
Бэкенд через resilience-pipeline ретраит 4 раза с экспонентой ~5s — UI выглядит как «зависло».

## Root cause
Канонический порт sidecar — `5060`:
- `backend/src/Mozgoslav.Api/appsettings.json` → `Mozgoslav:PythonSidecar:BaseUrl: http://127.0.0.1:5060`
- `python-sidecar/app/config.py` → `port: int = Field(default=5060, ...)`
- `python-sidecar/README.md` и docstring `app/main.py` — везде 5060

Только `scripts/demo.command` поднимал uvicorn на `--port 5051`. Любая попытка backend → sidecar упиралась в connection refused, embed валился в bag-of-words fallback.

## Fix
Одна строка: `--port 5051` → `--port 5060`. Лаунчер теперь поднимает sidecar там же, где его ждёт backend.

## Test plan
- [x] `bash -n scripts/demo.command` — синтаксис чистый.
- [x] Ручная проверка: единственная разница порта в репо находится только в этом файле (`grep 5051` по репо — больше нигде не используется).
- [ ] У тебя на маке: `lsof -ti :5051 | xargs kill`, затем перезапуск `scripts/demo.command` — sidecar поднимется на 5060, backend embed заработает.

🤖 Generated with [Claude Code](https://claude.com/claude-code)