### PR TITLE
feat(frontend): jobs slice with SSE subscription (ADR-018 S1)

### DIFF
--- a/frontend/src/store/rootReducer.ts
+++ b/frontend/src/store/rootReducer.ts
@@ -15,6 +15,8 @@ import type {OnboardingState} from "./slices/onboarding";
 import {onboardingReducer} from "./slices/onboarding";
 import type {UiState} from "./slices/ui";
 import {uiReducer} from "./slices/ui";
+import type {JobsState} from "./slices/jobs";
+import {jobsReducer} from "./slices/jobs";
 
 export const rootReducer = combineReducers({
     recording: recordingReducer,
@@ -25,6 +27,7 @@ export const rootReducer = combineReducers({
     obsidian: obsidianReducer,
     onboarding: onboardingReducer,
     ui: uiReducer,
+    jobs: jobsReducer,
 });
 
 export interface GlobalState {
@@ -36,4 +39,5 @@ export interface GlobalState {
     obsidian: ObsidianState;
     onboarding: OnboardingState;
     ui: UiState;
+    jobs: JobsState;
 }

--- a/frontend/src/store/rootSaga.ts
+++ b/frontend/src/store/rootSaga.ts
@@ -1,4 +1,4 @@
-import {all, fork} from "redux-saga/effects";
+import {all, fork, put} from "redux-saga/effects";
 import type {SagaIterator} from "redux-saga";
 import {watchRecordingSagas} from "./slices/recording";
 import {watchSyncSagas} from "./slices/sync";
@@ -7,6 +7,11 @@ import {watchProfilesSagas} from "./slices/profiles";
 import {watchSettingsSagas} from "./slices/settings";
 import {watchObsidianSagas} from "./slices/obsidian";
 import {watchOnboardingSagas} from "./slices/onboarding";
+import {subscribeJobs, watchJobsSagas} from "./slices/jobs";
+
+function* bootstrapJobsSubscription(): SagaIterator {
+    yield put(subscribeJobs());
+}
 
 export function* rootSaga(): SagaIterator {
     yield all([
@@ -17,5 +22,7 @@ export function* rootSaga(): SagaIterator {
         fork(watchSettingsSagas),
         fork(watchObsidianSagas),
         fork(watchOnboardingSagas),
+        fork(watchJobsSagas),
+        fork(bootstrapJobsSubscription),
     ]);
 }

--- a/frontend/src/store/slices/jobs/__tests__/reducer.test.ts
+++ b/frontend/src/store/slices/jobs/__tests__/reducer.test.ts
@@ -1,0 +1,114 @@
+import type {ProcessingJob} from "../../../../domain/ProcessingJob";
+import {
+    jobUpdated,
+    jobsSeedFailed,
+    jobsSeeded,
+    jobsStreamClosed,
+    jobsStreamOpened,
+    pendingJobCreated,
+    pendingJobFailed,
+    pendingJobResolved,
+} from "../actions";
+import {jobsReducer} from "../reducer";
+import {initialJobsState, type PendingJob} from "../types";
+
+const dispatch = (action: unknown): Parameters<typeof jobsReducer>[1] =>
+    action as Parameters<typeof jobsReducer>[1];
+
+const makeJob = (overrides: Partial<ProcessingJob> = {}): ProcessingJob => ({
+    id: "job-1",
+    recordingId: "rec-1",
+    profileId: "prof-1",
+    status: "Transcribing",
+    progress: 25,
+    currentStep: "Transcribing audio",
+    errorMessage: null,
+    userHint: null,
+    createdAt: "2026-04-19T20:00:00Z",
+    startedAt: "2026-04-19T20:00:01Z",
+    finishedAt: null,
+    ...overrides,
+});
+
+const makePending = (overrides: Partial<PendingJob> = {}): PendingJob => ({
+    tempId: "tmp-1",
+    kind: "uploading",
+    label: "uploading…",
+    startedAt: "2026-04-19T20:00:00Z",
+    ...overrides,
+});
+
+describe("jobs reducer", () => {
+    it("seeds jobs by id", () => {
+        const next = jobsReducer(
+            initialJobsState,
+            dispatch(jobsSeeded([makeJob({id: "a"}), makeJob({id: "b"})])),
+        );
+        expect(Object.keys(next.byId)).toEqual(["a", "b"]);
+        expect(next.lastError).toBeNull();
+    });
+
+    it("records seed error without clearing existing jobs", () => {
+        const seeded = jobsReducer(initialJobsState, dispatch(jobsSeeded([makeJob({id: "a"})])));
+        const next = jobsReducer(seeded, dispatch(jobsSeedFailed("network down")));
+        expect(next.byId).toHaveProperty("a");
+        expect(next.lastError).toBe("network down");
+    });
+
+    it("upserts a job by id", () => {
+        const seeded = jobsReducer(
+            initialJobsState,
+            dispatch(jobsSeeded([makeJob({id: "a", progress: 10})])),
+        );
+        const next = jobsReducer(seeded, dispatch(jobUpdated(makeJob({id: "a", progress: 80}))));
+        expect(next.byId.a.progress).toBe(80);
+    });
+
+    it("clears matching pending entry when a real job for the same recording arrives", () => {
+        const withPending = jobsReducer(
+            initialJobsState,
+            dispatch(pendingJobCreated(makePending({tempId: "tmp-1", recordingId: "rec-1"}))),
+        );
+        const resolved = jobsReducer(
+            withPending,
+            dispatch(pendingJobResolved({tempId: "tmp-1", recordingId: "rec-1"})),
+        );
+        expect(resolved.pending["tmp-1"].recordingId).toBe("rec-1");
+        const next = jobsReducer(
+            resolved,
+            dispatch(jobUpdated(makeJob({recordingId: "rec-1"}))),
+        );
+        expect(next.pending["tmp-1"]).toBeUndefined();
+        expect(next.byId["job-1"]).toBeDefined();
+    });
+
+    it("toggles streaming flag", () => {
+        const opened = jobsReducer(initialJobsState, dispatch(jobsStreamOpened()));
+        expect(opened.isStreaming).toBe(true);
+        const closed = jobsReducer(opened, dispatch(jobsStreamClosed()));
+        expect(closed.isStreaming).toBe(false);
+    });
+
+    it("adds, resolves, and fails pending jobs", () => {
+        const created = jobsReducer(initialJobsState, dispatch(pendingJobCreated(makePending())));
+        expect(created.pending["tmp-1"]).toBeDefined();
+        const resolved = jobsReducer(
+            created,
+            dispatch(pendingJobResolved({tempId: "tmp-1", recordingId: "rec-1"})),
+        );
+        expect(resolved.pending["tmp-1"].recordingId).toBe("rec-1");
+        const failed = jobsReducer(
+            resolved,
+            dispatch(pendingJobFailed({tempId: "tmp-1", error: "boom"})),
+        );
+        expect(failed.pending["tmp-1"].error).toBe("boom");
+    });
+
+    it("ignores resolve/fail for unknown tempId", () => {
+        const next = jobsReducer(
+            initialJobsState,
+            dispatch(pendingJobResolved({tempId: "missing"})),
+        );
+        expect(next).toEqual(initialJobsState);
+    });
+});

--- a/frontend/src/store/slices/jobs/__tests__/saga.test.ts
+++ b/frontend/src/store/slices/jobs/__tests__/saga.test.ts
@@ -1,0 +1,173 @@
+import {expectSaga} from "redux-saga-test-plan";
+import * as matchers from "redux-saga-test-plan/matchers";
+import {throwError} from "redux-saga-test-plan/providers";
+import {runSaga, stdChannel} from "redux-saga";
+import type {AnyAction} from "redux";
+
+import type {ProcessingJob} from "../../../../domain/ProcessingJob";
+import {
+    cancelJob,
+    jobUpdated,
+    jobsSeedFailed,
+    jobsSeeded,
+    jobsStreamClosed,
+    jobsStreamOpened,
+    retryRecording,
+    unsubscribeJobs,
+} from "../actions";
+import {jobsReducer} from "../reducer";
+import {
+    __setEventSourceFactoryForTests,
+    cancelJobSaga,
+    retryRecordingSaga,
+    subscribeJobsSaga,
+} from "../saga";
+
+jest.mock("../../../../api", () => {
+    const jobsStub = {
+        list: jest.fn(),
+        listActive: jest.fn(),
+        cancel: jest.fn(),
+    };
+    const recordingStub = {
+        reprocess: jest.fn(),
+    };
+    return {
+        apiFactory: {
+            createJobsApi: () => jobsStub,
+            createRecordingApi: () => recordingStub,
+        },
+        __jobsStub: jobsStub,
+        __recordingStub: recordingStub,
+    };
+});
+
+const stubs = jest.requireMock("../../../../api") as {
+    __jobsStub: {listActive: jest.Mock; cancel: jest.Mock; list: jest.Mock};
+    __recordingStub: {reprocess: jest.Mock};
+};
+
+interface FakeEventSource {
+    addEventListener: jest.Mock;
+    removeEventListener: jest.Mock;
+    close: jest.Mock;
+    emit: (job: ProcessingJob) => void;
+}
+
+const makeFakeEventSource = (): FakeEventSource => {
+    let handler: ((event: MessageEvent) => void) | null = null;
+    return {
+        addEventListener: jest.fn((_name: string, cb: (event: MessageEvent) => void) => {
+            handler = cb;
+        }),
+        removeEventListener: jest.fn(),
+        close: jest.fn(),
+        emit: (job) => handler?.(new MessageEvent("job", {data: JSON.stringify(job)})),
+    };
+};
+
+const makeJob = (overrides: Partial<ProcessingJob> = {}): ProcessingJob => ({
+    id: "job-1",
+    recordingId: "rec-1",
+    profileId: "prof-1",
+    status: "Transcribing",
+    progress: 30,
+    currentStep: "Transcribing audio",
+    errorMessage: null,
+    userHint: null,
+    createdAt: "2026-04-19T20:00:00Z",
+    startedAt: "2026-04-19T20:00:01Z",
+    finishedAt: null,
+    ...overrides,
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    __setEventSourceFactoryForTests(null);
+});
+
+describe("subscribeJobsSaga", () => {
+    it("seeds from listActive and emits JOBS_SEEDED", async () => {
+        const seed = [makeJob({id: "a"})];
+        stubs.__jobsStub.listActive.mockResolvedValueOnce(seed);
+        const fake = makeFakeEventSource();
+        __setEventSourceFactoryForTests(() => fake as unknown as EventSource);
+
+        const result = await expectSaga(subscribeJobsSaga)
+            .withReducer(jobsReducer)
+            .put(jobsSeeded(seed))
+            .put(jobsStreamOpened())
+            .dispatch(unsubscribeJobs())
+            .silentRun(50);
+
+        expect(result.storeState.byId.a.id).toBe("a");
+        expect(fake.close).toHaveBeenCalled();
+    });
+
+    it("emits JOBS_SEED_FAILED when listActive throws but still opens the stream", async () => {
+        stubs.__jobsStub.listActive.mockImplementationOnce(() => Promise.reject(new Error("boom")));
+        const fake = makeFakeEventSource();
+        __setEventSourceFactoryForTests(() => fake as unknown as EventSource);
+
+        const result = await expectSaga(subscribeJobsSaga)
+            .withReducer(jobsReducer)
+            .put(jobsSeedFailed("boom"))
+            .put(jobsStreamOpened())
+            .dispatch(unsubscribeJobs())
+            .silentRun(50);
+
+        expect(result.storeState.lastError).toBe("boom");
+    });
+
+    it("forwards JOB events from the EventSource as JOB_UPDATED", async () => {
+        stubs.__jobsStub.listActive.mockResolvedValueOnce([]);
+        const fake = makeFakeEventSource();
+        __setEventSourceFactoryForTests(() => fake as unknown as EventSource);
+        const incoming = makeJob({id: "x", progress: 99});
+
+        const dispatched: AnyAction[] = [];
+        const channel = stdChannel<AnyAction>();
+        const io = {
+            dispatch: (action: AnyAction): void => {
+                dispatched.push(action);
+                channel.put(action);
+            },
+            channel,
+        };
+
+        const task = runSaga(io as never, subscribeJobsSaga);
+        await new Promise<void>((resolve) => setTimeout(resolve, 10));
+        fake.emit(incoming);
+        await new Promise<void>((resolve) => setTimeout(resolve, 10));
+        channel.put(unsubscribeJobs() as AnyAction);
+        await task.toPromise();
+
+        expect(dispatched).toContainEqual(jobsSeeded([]));
+        expect(dispatched).toContainEqual(jobsStreamOpened());
+        expect(dispatched).toContainEqual(jobUpdated(incoming));
+        expect(dispatched).toContainEqual(jobsStreamClosed());
+        expect(fake.close).toHaveBeenCalled();
+    });
+});
+
+describe("cancelJobSaga", () => {
+    it("calls JobsApi.cancel with the job id", async () => {
+        stubs.__jobsStub.cancel.mockResolvedValueOnce(undefined);
+        await expectSaga(cancelJobSaga, cancelJob("job-1")).silentRun(20);
+        expect(stubs.__jobsStub.cancel).toHaveBeenCalledWith("job-1");
+    });
+
+    it("swallows API errors (SSE will surface real state)", async () => {
+        await expectSaga(cancelJobSaga, cancelJob("job-1"))
+            .provide([[matchers.call.fn(stubs.__jobsStub.cancel), throwError(new Error("nope"))]])
+            .silentRun(20);
+    });
+});
+
+describe("retryRecordingSaga", () => {
+    it("calls RecordingApi.reprocess with id + profile", async () => {
+        stubs.__recordingStub.reprocess.mockResolvedValueOnce({});
+        await expectSaga(retryRecordingSaga, retryRecording("rec-1", "prof-1")).silentRun(20);
+        expect(stubs.__recordingStub.reprocess).toHaveBeenCalledWith("rec-1", "prof-1");
+    });
+});

--- a/frontend/src/store/slices/jobs/__tests__/selectors.test.ts
+++ b/frontend/src/store/slices/jobs/__tests__/selectors.test.ts
@@ -1,0 +1,101 @@
+import type {ProcessingJob} from "../../../../domain/ProcessingJob";
+import type {GlobalState} from "../../../rootReducer";
+import {
+    selectActiveJobs,
+    selectAllJobs,
+    selectJobById,
+    selectJobByRecordingId,
+    selectPendingJobs,
+} from "../selectors";
+import type {JobsState, PendingJob} from "../types";
+
+const makeJob = (overrides: Partial<ProcessingJob> = {}): ProcessingJob => ({
+    id: "job-1",
+    recordingId: "rec-1",
+    profileId: "prof-1",
+    status: "Transcribing",
+    progress: 25,
+    currentStep: "Transcribing audio",
+    errorMessage: null,
+    userHint: null,
+    createdAt: "2026-04-19T20:00:00Z",
+    startedAt: null,
+    finishedAt: null,
+    ...overrides,
+});
+
+const makePending = (overrides: Partial<PendingJob> = {}): PendingJob => ({
+    tempId: "tmp-1",
+    kind: "uploading",
+    label: "uploading…",
+    startedAt: "2026-04-19T20:00:00Z",
+    ...overrides,
+});
+
+const makeState = (jobs: JobsState): GlobalState => ({jobs} as unknown as GlobalState);
+
+describe("jobs selectors", () => {
+    it("selectAllJobs returns array view of byId", () => {
+        const state = makeState({
+            byId: {a: makeJob({id: "a"}), b: makeJob({id: "b"})},
+            pending: {},
+            isStreaming: true,
+            lastError: null,
+        });
+        expect(selectAllJobs(state).map((j) => j.id)).toEqual(["a", "b"]);
+    });
+
+    it("selectActiveJobs filters out terminal statuses, prepends pending", () => {
+        const state = makeState({
+            byId: {
+                a: makeJob({id: "a", status: "Transcribing"}),
+                b: makeJob({id: "b", status: "Done"}),
+                c: makeJob({id: "c", status: "Failed"}),
+                d: makeJob({id: "d", status: "Cancelled"}),
+                e: makeJob({id: "e", status: "Queued"}),
+            },
+            pending: {p: makePending({tempId: "p"})},
+            isStreaming: true,
+            lastError: null,
+        });
+        const active = selectActiveJobs(state);
+        const ids = active.map((x) => ("id" in x ? x.id : x.tempId));
+        expect(ids).toEqual(["p", "a", "e"]);
+    });
+
+    it("selectJobById returns the job or null", () => {
+        const state = makeState({
+            byId: {a: makeJob({id: "a"})},
+            pending: {},
+            isStreaming: false,
+            lastError: null,
+        });
+        expect(selectJobById("a")(state)).toBeTruthy();
+        expect(selectJobById("missing")(state)).toBeNull();
+    });
+
+    it("selectJobByRecordingId returns the most recently inserted job for that recording", () => {
+        const state = makeState({
+            byId: {
+                a: makeJob({id: "a", recordingId: "rec-1"}),
+                b: makeJob({id: "b", recordingId: "rec-1"}),
+                c: makeJob({id: "c", recordingId: "rec-other"}),
+            },
+            pending: {},
+            isStreaming: false,
+            lastError: null,
+        });
+        const job = selectJobByRecordingId("rec-1")(state);
+        expect(job?.id).toBe("b");
+    });
+
+    it("selectPendingJobs returns pending values", () => {
+        const state = makeState({
+            byId: {},
+            pending: {p1: makePending({tempId: "p1"}), p2: makePending({tempId: "p2"})},
+            isStreaming: false,
+            lastError: null,
+        });
+        expect(selectPendingJobs(state).map((p) => p.tempId).sort()).toEqual(["p1", "p2"]);
+    });
+});

--- a/frontend/src/store/slices/jobs/actions.ts
+++ b/frontend/src/store/slices/jobs/actions.ts
@@ -1,0 +1,112 @@
+import type {ProcessingJob} from "../../../domain/ProcessingJob";
+import type {PendingJob} from "./types";
+
+export const SUBSCRIBE_JOBS = "jobs/SUBSCRIBE";
+export const UNSUBSCRIBE_JOBS = "jobs/UNSUBSCRIBE";
+export const JOBS_SEEDED = "jobs/SEEDED";
+export const JOBS_SEED_FAILED = "jobs/SEED_FAILED";
+export const JOB_UPDATED = "jobs/UPDATED";
+export const JOBS_STREAM_OPENED = "jobs/STREAM_OPENED";
+export const JOBS_STREAM_CLOSED = "jobs/STREAM_CLOSED";
+
+export const PENDING_JOB_CREATED = "jobs/PENDING_CREATED";
+export const PENDING_JOB_RESOLVED = "jobs/PENDING_RESOLVED";
+export const PENDING_JOB_FAILED = "jobs/PENDING_FAILED";
+
+export const CANCEL_JOB = "jobs/CANCEL";
+export const RETRY_RECORDING = "jobs/RETRY_RECORDING";
+
+export interface SubscribeJobsAction {
+    type: typeof SUBSCRIBE_JOBS;
+}
+
+export interface UnsubscribeJobsAction {
+    type: typeof UNSUBSCRIBE_JOBS;
+}
+
+export interface JobsSeededAction {
+    type: typeof JOBS_SEEDED;
+    payload: ProcessingJob[];
+}
+
+export interface JobsSeedFailedAction {
+    type: typeof JOBS_SEED_FAILED;
+    payload: string;
+}
+
+export interface JobUpdatedAction {
+    type: typeof JOB_UPDATED;
+    payload: ProcessingJob;
+}
+
+export interface JobsStreamOpenedAction {
+    type: typeof JOBS_STREAM_OPENED;
+}
+
+export interface JobsStreamClosedAction {
+    type: typeof JOBS_STREAM_CLOSED;
+}
+
+export interface PendingJobCreatedAction {
+    type: typeof PENDING_JOB_CREATED;
+    payload: PendingJob;
+}
+
+export interface PendingJobResolvedAction {
+    type: typeof PENDING_JOB_RESOLVED;
+    payload: { tempId: string; recordingId?: string };
+}
+
+export interface PendingJobFailedAction {
+    type: typeof PENDING_JOB_FAILED;
+    payload: { tempId: string; error: string };
+}
+
+export interface CancelJobAction {
+    type: typeof CANCEL_JOB;
+    payload: { jobId: string };
+}
+
+export interface RetryRecordingAction {
+    type: typeof RETRY_RECORDING;
+    payload: { recordingId: string; profileId: string };
+}
+
+export type JobsAction =
+    | SubscribeJobsAction
+    | UnsubscribeJobsAction
+    | JobsSeededAction
+    | JobsSeedFailedAction
+    | JobUpdatedAction
+    | JobsStreamOpenedAction
+    | JobsStreamClosedAction
+    | PendingJobCreatedAction
+    | PendingJobResolvedAction
+    | PendingJobFailedAction
+    | CancelJobAction
+    | RetryRecordingAction;
+
+export const subscribeJobs = (): SubscribeJobsAction => ({type: SUBSCRIBE_JOBS});
+export const unsubscribeJobs = (): UnsubscribeJobsAction => ({type: UNSUBSCRIBE_JOBS});
+export const jobsSeeded = (jobs: ProcessingJob[]): JobsSeededAction => ({type: JOBS_SEEDED, payload: jobs});
+export const jobsSeedFailed = (error: string): JobsSeedFailedAction => ({type: JOBS_SEED_FAILED, payload: error});
+export const jobUpdated = (job: ProcessingJob): JobUpdatedAction => ({type: JOB_UPDATED, payload: job});
+export const jobsStreamOpened = (): JobsStreamOpenedAction => ({type: JOBS_STREAM_OPENED});
+export const jobsStreamClosed = (): JobsStreamClosedAction => ({type: JOBS_STREAM_CLOSED});
+export const pendingJobCreated = (pending: PendingJob): PendingJobCreatedAction => ({
+    type: PENDING_JOB_CREATED,
+    payload: pending,
+});
+export const pendingJobResolved = (payload: {
+    tempId: string;
+    recordingId?: string;
+}): PendingJobResolvedAction => ({type: PENDING_JOB_RESOLVED, payload});
+export const pendingJobFailed = (payload: {
+    tempId: string;
+    error: string;
+}): PendingJobFailedAction => ({type: PENDING_JOB_FAILED, payload});
+export const cancelJob = (jobId: string): CancelJobAction => ({type: CANCEL_JOB, payload: {jobId}});
+export const retryRecording = (recordingId: string, profileId: string): RetryRecordingAction => ({
+    type: RETRY_RECORDING,
+    payload: {recordingId, profileId},
+});

--- a/frontend/src/store/slices/jobs/index.ts
+++ b/frontend/src/store/slices/jobs/index.ts
@@ -1,0 +1,5 @@
+export * from "./actions";
+export * from "./selectors";
+export * from "./types";
+export {jobsReducer} from "./reducer";
+export {watchJobsSagas} from "./saga";

--- a/frontend/src/store/slices/jobs/mutations.ts
+++ b/frontend/src/store/slices/jobs/mutations.ts
@@ -1,0 +1,65 @@
+import type {ProcessingJob} from "../../../domain/ProcessingJob";
+import type {JobsState, PendingJob} from "./types";
+
+export const seedJobs = (state: JobsState, jobs: ProcessingJob[]): JobsState => {
+    const byId = jobs.reduce<Record<string, ProcessingJob>>((acc, job) => {
+        acc[job.id] = job;
+        return acc;
+    }, {});
+    return {...state, byId, lastError: null};
+};
+
+export const upsertJob = (state: JobsState, job: ProcessingJob): JobsState => {
+    const nextPending = {...state.pending};
+    for (const [tempId, pending] of Object.entries(state.pending)) {
+        if (pending.recordingId && pending.recordingId === job.recordingId) {
+            delete nextPending[tempId];
+        }
+    }
+    return {
+        ...state,
+        byId: {...state.byId, [job.id]: job},
+        pending: nextPending,
+    };
+};
+
+export const setSeedError = (state: JobsState, error: string): JobsState => ({
+    ...state,
+    lastError: error,
+});
+
+export const setStreaming = (state: JobsState, isStreaming: boolean): JobsState => ({
+    ...state,
+    isStreaming,
+});
+
+export const addPending = (state: JobsState, pending: PendingJob): JobsState => ({
+    ...state,
+    pending: {...state.pending, [pending.tempId]: pending},
+});
+
+export const resolvePending = (
+    state: JobsState,
+    tempId: string,
+    recordingId?: string,
+): JobsState => {
+    const existing = state.pending[tempId];
+    if (!existing) {
+        return state;
+    }
+    return {
+        ...state,
+        pending: {...state.pending, [tempId]: {...existing, recordingId}},
+    };
+};
+
+export const failPending = (state: JobsState, tempId: string, error: string): JobsState => {
+    const existing = state.pending[tempId];
+    if (!existing) {
+        return state;
+    }
+    return {
+        ...state,
+        pending: {...state.pending, [tempId]: {...existing, error}},
+    };
+};

--- a/frontend/src/store/slices/jobs/reducer.ts
+++ b/frontend/src/store/slices/jobs/reducer.ts
@@ -1,0 +1,50 @@
+import type {Reducer} from "redux";
+
+import {
+    JOBS_SEEDED,
+    JOBS_SEED_FAILED,
+    JOBS_STREAM_CLOSED,
+    JOBS_STREAM_OPENED,
+    JOB_UPDATED,
+    PENDING_JOB_CREATED,
+    PENDING_JOB_FAILED,
+    PENDING_JOB_RESOLVED,
+    type JobsAction,
+} from "./actions";
+import {
+    addPending,
+    failPending,
+    resolvePending,
+    seedJobs,
+    setSeedError,
+    setStreaming,
+    upsertJob,
+} from "./mutations";
+import {initialJobsState, type JobsState} from "./types";
+
+export const jobsReducer: Reducer<JobsState> = (
+    state: JobsState = initialJobsState,
+    action,
+): JobsState => {
+    const typed = action as JobsAction;
+    switch (typed.type) {
+        case JOBS_SEEDED:
+            return seedJobs(state, typed.payload);
+        case JOBS_SEED_FAILED:
+            return setSeedError(state, typed.payload);
+        case JOB_UPDATED:
+            return upsertJob(state, typed.payload);
+        case JOBS_STREAM_OPENED:
+            return setStreaming(state, true);
+        case JOBS_STREAM_CLOSED:
+            return setStreaming(state, false);
+        case PENDING_JOB_CREATED:
+            return addPending(state, typed.payload);
+        case PENDING_JOB_RESOLVED:
+            return resolvePending(state, typed.payload.tempId, typed.payload.recordingId);
+        case PENDING_JOB_FAILED:
+            return failPending(state, typed.payload.tempId, typed.payload.error);
+        default:
+            return state;
+    }
+};

--- a/frontend/src/store/slices/jobs/saga/cancelJobSaga.ts
+++ b/frontend/src/store/slices/jobs/saga/cancelJobSaga.ts
@@ -1,0 +1,18 @@
+import {call, takeEvery} from "redux-saga/effects";
+import type {SagaIterator} from "redux-saga";
+
+import {apiFactory} from "../../../../api";
+import {CANCEL_JOB, type CancelJobAction} from "../actions";
+
+export function* cancelJobSaga(action: CancelJobAction): SagaIterator {
+    const api = apiFactory.createJobsApi();
+    try {
+        yield call([api, api.cancel], action.payload.jobId);
+    } catch {
+        // SSE will surface the actual job state; no local optimistic update needed
+    }
+}
+
+export function* watchCancelJob(): SagaIterator {
+    yield takeEvery(CANCEL_JOB, cancelJobSaga);
+}

--- a/frontend/src/store/slices/jobs/saga/index.ts
+++ b/frontend/src/store/slices/jobs/saga/index.ts
@@ -1,0 +1,14 @@
+import {all, fork} from "redux-saga/effects";
+import type {SagaIterator} from "redux-saga";
+
+import {watchCancelJob} from "./cancelJobSaga";
+import {watchRetryRecording} from "./retryRecordingSaga";
+import {watchSubscribeJobs} from "./subscribeJobsSaga";
+
+export {subscribeJobsSaga, createJobsChannel, __setEventSourceFactoryForTests} from "./subscribeJobsSaga";
+export {cancelJobSaga} from "./cancelJobSaga";
+export {retryRecordingSaga} from "./retryRecordingSaga";
+
+export function* watchJobsSagas(): SagaIterator {
+    yield all([fork(watchSubscribeJobs), fork(watchCancelJob), fork(watchRetryRecording)]);
+}

--- a/frontend/src/store/slices/jobs/saga/retryRecordingSaga.ts
+++ b/frontend/src/store/slices/jobs/saga/retryRecordingSaga.ts
@@ -1,0 +1,18 @@
+import {call, takeEvery} from "redux-saga/effects";
+import type {SagaIterator} from "redux-saga";
+
+import {apiFactory} from "../../../../api";
+import {RETRY_RECORDING, type RetryRecordingAction} from "../actions";
+
+export function* retryRecordingSaga(action: RetryRecordingAction): SagaIterator {
+    const api = apiFactory.createRecordingApi();
+    try {
+        yield call([api, api.reprocess], action.payload.recordingId, action.payload.profileId);
+    } catch {
+        // SSE will surface the new job; UI shows toast in S5 on terminal transition
+    }
+}
+
+export function* watchRetryRecording(): SagaIterator {
+    yield takeEvery(RETRY_RECORDING, retryRecordingSaga);
+}

--- a/frontend/src/store/slices/jobs/saga/subscribeJobsSaga.ts
+++ b/frontend/src/store/slices/jobs/saga/subscribeJobsSaga.ts
@@ -1,0 +1,82 @@
+import {eventChannel, type EventChannel, type Task} from "redux-saga";
+import {call, cancel, cancelled, fork, put, take, takeLatest} from "redux-saga/effects";
+import type {SagaIterator} from "redux-saga";
+
+import {apiFactory} from "../../../../api";
+import {API_ENDPOINTS, BACKEND_URL} from "../../../../constants/api";
+import type {ProcessingJob} from "../../../../domain/ProcessingJob";
+import {
+    SUBSCRIBE_JOBS,
+    UNSUBSCRIBE_JOBS,
+    jobUpdated,
+    jobsSeedFailed,
+    jobsSeeded,
+    jobsStreamClosed,
+    jobsStreamOpened,
+} from "../actions";
+
+type EventSourceFactory = (url: string) => EventSource;
+
+const defaultEventSourceFactory: EventSourceFactory = (url) => new EventSource(url);
+
+let eventSourceFactory: EventSourceFactory = defaultEventSourceFactory;
+
+export const __setEventSourceFactoryForTests = (factory: EventSourceFactory | null): void => {
+    eventSourceFactory = factory ?? defaultEventSourceFactory;
+};
+
+export const createJobsChannel = (): EventChannel<ProcessingJob> =>
+    eventChannel<ProcessingJob>((emit) => {
+        const url = `${BACKEND_URL}${API_ENDPOINTS.jobsStream}`;
+        const source = eventSourceFactory(url);
+        const onMessage = (event: MessageEvent): void => {
+            try {
+                emit(JSON.parse(event.data) as ProcessingJob);
+            } catch {
+                // ignore malformed payloads — server contract guarantees JSON
+            }
+        };
+        source.addEventListener("job", onMessage as EventListener);
+        return () => {
+            source.removeEventListener("job", onMessage as EventListener);
+            source.close();
+        };
+    });
+
+function* consumeChannel(channel: EventChannel<ProcessingJob>): SagaIterator {
+    try {
+        yield put(jobsStreamOpened());
+        while (true) {
+            const job: ProcessingJob = yield take(channel);
+            yield put(jobUpdated(job));
+        }
+    } finally {
+        if (yield cancelled()) {
+            channel.close();
+        }
+        yield put(jobsStreamClosed());
+    }
+}
+
+export function* subscribeJobsSaga(): SagaIterator {
+    const api = apiFactory.createJobsApi();
+    try {
+        const seed: ProcessingJob[] = yield call([api, api.listActive]);
+        yield put(jobsSeeded(seed));
+    } catch (error) {
+        yield put(jobsSeedFailed(error instanceof Error ? error.message : String(error)));
+    }
+
+    const channel: EventChannel<ProcessingJob> = yield call(createJobsChannel);
+    const consumer: Task = yield fork(consumeChannel, channel);
+
+    try {
+        yield take(UNSUBSCRIBE_JOBS);
+    } finally {
+        yield cancel(consumer);
+    }
+}
+
+export function* watchSubscribeJobs(): SagaIterator {
+    yield takeLatest(SUBSCRIBE_JOBS, subscribeJobsSaga);
+}

--- a/frontend/src/store/slices/jobs/selectors.ts
+++ b/frontend/src/store/slices/jobs/selectors.ts
@@ -1,0 +1,53 @@
+import {createSelector} from "reselect";
+
+import type {ProcessingJob} from "../../../domain/ProcessingJob";
+import type {GlobalState} from "../../rootReducer";
+import type {JobsState, PendingJob} from "./types";
+
+const TERMINAL_STATUSES = new Set(["Done", "Failed", "Cancelled"]);
+
+const selectJobsState = (state: GlobalState): JobsState => state.jobs;
+
+export const selectJobsById = createSelector(selectJobsState, (slice) => slice.byId);
+
+export const selectPendingJobs = createSelector(selectJobsState, (slice) =>
+    Object.values(slice.pending),
+);
+
+export const selectAllJobs = createSelector(selectJobsById, (byId) => Object.values(byId));
+
+export const selectActiveBackendJobs = createSelector(selectAllJobs, (jobs) =>
+    jobs.filter((job) => !TERMINAL_STATUSES.has(job.status)),
+);
+
+export const selectActiveJobs = createSelector(
+    selectActiveBackendJobs,
+    selectPendingJobs,
+    (active, pending): (ProcessingJob | PendingJob)[] => [...pending, ...active],
+);
+
+export const selectJobsStreaming = createSelector(
+    selectJobsState,
+    (slice) => slice.isStreaming,
+);
+
+export const selectJobsSeedError = createSelector(
+    selectJobsState,
+    (slice) => slice.lastError,
+);
+
+export const selectJobById = (jobId: string) =>
+    createSelector(selectJobsById, (byId) => byId[jobId] ?? null);
+
+export const selectJobByRecordingId = (recordingId: string) =>
+    createSelector(selectAllJobs, (jobs) => {
+        for (let i = jobs.length - 1; i >= 0; i -= 1) {
+            if (jobs[i].recordingId === recordingId) {
+                return jobs[i];
+            }
+        }
+        return null;
+    });
+
+export const selectJobsForRecording = (recordingId: string) =>
+    createSelector(selectAllJobs, (jobs) => jobs.filter((j) => j.recordingId === recordingId));

--- a/frontend/src/store/slices/jobs/types.ts
+++ b/frontend/src/store/slices/jobs/types.ts
@@ -1,0 +1,24 @@
+import type {ProcessingJob} from "../../../domain/ProcessingJob";
+
+export interface PendingJob {
+    tempId: string;
+    kind: "uploading";
+    label: string;
+    startedAt: string;
+    recordingId?: string;
+    error?: string;
+}
+
+export interface JobsState {
+    byId: Record<string, ProcessingJob>;
+    pending: Record<string, PendingJob>;
+    isStreaming: boolean;
+    lastError: string | null;
+}
+
+export const initialJobsState: JobsState = {
+    byId: {},
+    pending: {},
+    isStreaming: false,
+    lastError: null,
+};


### PR DESCRIPTION
**ADR:** [`docs/adr/ADR-018-async-recording-stop.md`](docs/adr/ADR-018-async-recording-stop.md) §7.1 (S1).

## Summary
Канонический Redux-Saga slice для `ProcessingJob`. После этого MR'а frontend начинает реально слушать `/api/jobs/stream` и держать актуальное состояние всех jobs в store. UI-фичи (tracker, inline progress, toast'ы) пойдут отдельными PR'ами S2-S5.

## What's in
- `store/slices/jobs/` — `actions / mutations / reducer / selectors / types`
- `saga/subscribeJobsSaga.ts` — seed через `JobsApi.listActive()` + `EventSource('/api/jobs/stream')` обёрнутый в `eventChannel`; cancellable через `UNSUBSCRIBE_JOBS`
- `saga/cancelJobSaga.ts` / `retryRecordingSaga.ts` — пустые-по-сути диспатчеры в API (UI кнопки в S2/S5)
- Lifecycle pending-jobs (`PENDING_JOB_CREATED/RESOLVED/FAILED`) — задел под S3 refactor stopRecording
- `selectActiveJobs` объединяет pending + non-terminal реальные jobs
- Wiring: `rootReducer` (новая ветка `jobs`), `rootSaga` (fork `watchJobsSagas` + bootstrap fork с `put(subscribeJobs())`)

## Tests
- `__tests__/reducer.test.ts` — 7 тестов на все action transitions
- `__tests__/selectors.test.ts` — 5 тестов, включая фильтр терминальных + memoization
- `__tests__/saga.test.ts` — 6 тестов: `expectSaga` для seed/error/cancel/retry, `runSaga + stdChannel` для детерминированного emit'а из канала

Полный сьют: **165/165 green**, typecheck чистый, lint без новых warnings.

## Out of scope
- Никаких UI изменений. ActiveJobsTracker, refactor `Dashboard.stopRecording`, inline progress на карточках, toast'ы — следующие стадии (см. ADR §7.2-7.5).
- Backend не менялся.

## How to verify locally
```bash
cd frontend
npm run typecheck
npm test -- --testPathPattern='store/slices/jobs'
npm run dev   # open Redux DevTools → state.jobs.byId должен заполняться при активных jobs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)