### PR TITLE
fix(dictation): drop phantom mouse-button-5 fallback in push-to-talk wiring

### DIFF
--- a/frontend/electron/main.ts
+++ b/frontend/electron/main.ts
@@ -321,40 +321,28 @@ const applyCustomHotkeyFromSettings = async (): Promise<void> => {
             if (!response.ok) throw new Error(`status ${response.status}`);
             const settings = (await response.json()) as {
                 dictationKeyboardHotkey?: string;
-                dictationHotkeyType?: string;
-                dictationMouseButton?: number;
                 dictationPushToTalk?: boolean;
             };
             const custom = settings.dictationKeyboardHotkey?.trim() ?? "";
             const pushToTalk = settings.dictationPushToTalk === true;
-            const hotkeyType = settings.dictationHotkeyType ?? "mouse";
-            const mouseButton = settings.dictationMouseButton ?? 5;
             console.info("=".repeat(70));
             console.info(
-                `[hotkey] CHECKPOINT settings.custom='${custom}' settings.pushToTalk=${pushToTalk} settings.hotkeyType='${hotkeyType}' settings.mouseButton=${mouseButton} orchestratorReady=${dictationOrchestrator !== null}`,
+                `[hotkey] CHECKPOINT settings.custom='${custom}' settings.pushToTalk=${pushToTalk} orchestratorReady=${dictationOrchestrator !== null}`,
             );
 
-            if (pushToTalk && dictationOrchestrator) {
+            if (pushToTalk && dictationOrchestrator && custom) {
                 unregisterGlobalDictationHotkey();
                 console.info("[hotkey]   unregistered Electron globalShortcut");
                 try {
-                    if (hotkeyType === "keyboard" && custom) {
-                        console.info(`[hotkey] PATH -> Swift helper keyboard push-to-talk (cursor injection enabled) accelerator='${custom}'`);
-                        await dictationOrchestrator.configurePushToTalk({
-                            mouseButton: null,
-                            keyboardAccelerator: custom,
-                        });
-                    } else {
-                        console.info(`[hotkey] PATH -> uiohook mouse push-to-talk (cursor injection enabled) button=${mouseButton}`);
-                        await dictationOrchestrator.configurePushToTalk({
-                            mouseButton,
-                            keyboardAccelerator: null,
-                        });
-                    }
+                    console.info(`[hotkey] PATH -> Swift helper keyboard push-to-talk (cursor injection enabled) accelerator='${custom}'`);
+                    await dictationOrchestrator.configurePushToTalk({
+                        mouseButton: null,
+                        keyboardAccelerator: custom,
+                    });
                 } catch (err) {
                     console.warn("[hotkey] push-to-talk setup FAILED:", err);
                     console.warn("[hotkey] FALLBACK -> Electron globalShortcut toggle (NO cursor injection)");
-                    registerGlobalDictationHotkey(custom || undefined);
+                    registerGlobalDictationHotkey(custom);
                 }
                 return;
             }


### PR DESCRIPTION
Mode split via `DictationHotkeyType`/`DictationMouseButton` is unreachable — UI не выставляет эти поля, бекенд-дефолт навсегда `mouse`. Из-за этого клавиатурный хоткей, заданный пользователем, игнорировался в пользу жёстко зашитой mouse-5 ветки. Решение по пути диктовки теперь зависит только от `DictationKeyboardHotkey`: задан — Swift-helper keyboard push-to-talk; пусто — legacy toggle fallback.