### PR TITLE
fix(dictation): one-shot whisper on release, industry-standard push-to-talk

### DIFF
--- a/backend/src/Mozgoslav.Application/Interfaces/IStreamingTranscriptionService.cs
+++ b/backend/src/Mozgoslav.Application/Interfaces/IStreamingTranscriptionService.cs
@@ -1,20 +1,30 @@
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 
 using Mozgoslav.Domain.ValueObjects;
 
 namespace Mozgoslav.Application.Interfaces;
 
 /// <summary>
-/// Streaming counterpart to <see cref="ITranscriptionService"/>: consumes a live
-/// sequence of 16 kHz PCM audio chunks and emits partial transcripts as the
-/// model catches up. Used by the push-to-talk dictation pipeline where the user
-/// holds a hotkey and expects live feedback in the overlay.
+/// Dictation-side transcription: consumes either a live chunk stream (preview
+/// partials while the user holds the hotkey) or the whole per-session sample
+/// buffer on release (one-shot authoritative result that gets injected).
+/// Industry-standard push-to-talk tools (Superwhisper, MacWhisper, Voxtype,
+/// Whisper Notes) use the one-shot path for the final text because a single
+/// whisper pass with the full beam and full 30 s attention window is both
+/// faster and more accurate than greedy sliding windows for sub-minute speech.
 /// </summary>
 public interface IStreamingTranscriptionService
 {
     IAsyncEnumerable<PartialTranscript> TranscribeStreamAsync(
         IAsyncEnumerable<AudioChunk> chunks,
+        string language,
+        string? initialPrompt,
+        CancellationToken ct);
+
+    Task<string> TranscribeSamplesAsync(
+        float[] samples,
         string language,
         string? initialPrompt,
         CancellationToken ct);

--- a/backend/src/Mozgoslav.Application/Services/DictationSessionManager.cs
+++ b/backend/src/Mozgoslav.Application/Services/DictationSessionManager.cs
@@ -156,6 +156,7 @@ public sealed class DictationSessionManager : IDictationSessionManager
                     Samples: samples,
                     SampleRate: _pcmStream.TargetSampleRate,
                     Offset: TimeSpan.Zero);
+                runtime.AccumulatedChunks.Enqueue(chunk);
                 await runtime.AudioWriter.WriteAsync(chunk, runtime.Cts.Token).ConfigureAwait(false);
             }
         }
@@ -178,6 +179,7 @@ public sealed class DictationSessionManager : IDictationSessionManager
             throw new InvalidOperationException(
                 $"Session {sessionId} is not recording (state={runtime.Session.State}).");
         }
+        runtime.AccumulatedChunks.Enqueue(chunk);
         return runtime.AudioWriter.WriteAsync(chunk, ct);
     }
 
@@ -246,12 +248,32 @@ public sealed class DictationSessionManager : IDictationSessionManager
         }
         catch (Exception ex)
         {
-            MarkError(runtime, ex);
-            throw;
+            _logger.LogWarning(ex,
+                "Streaming preview task failed for session {SessionId}; continuing with one-shot transcription",
+                sessionId);
         }
 
         var duration = DateTime.UtcNow - runtime.Session.StartedAt;
-        var rawText = runtime.LastPartialText;
+        var accumulated = FlattenChunks(runtime.AccumulatedChunks);
+
+        string rawText;
+        try
+        {
+            rawText = await _streaming.TranscribeSamplesAsync(
+                accumulated,
+                _settings.DictationLanguage,
+                BuildInitialPrompt(runtime.Profile, _settings.DictationVocabulary),
+                ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            MarkError(runtime, ex);
+            throw;
+        }
 
         var profile = _perAppProfiles.Resolve(bundleId);
         var glossaryApplied = ApplyGlossary(rawText, profile);
@@ -272,10 +294,31 @@ public sealed class DictationSessionManager : IDictationSessionManager
         runtime.Dispose();
 
         _logger.LogInformation(
-            "Dictation session {SessionId} finalized in {Duration} ms, {Chars} chars",
-            sessionId, duration.TotalMilliseconds, rawText.Length);
+            "Dictation session {SessionId} finalized in {Duration} ms, {Chars} chars ({Samples} samples)",
+            sessionId, duration.TotalMilliseconds, rawText.Length, accumulated.Length);
 
         return new FinalTranscript(rawText, polished, duration);
+    }
+
+    private static float[] FlattenChunks(ConcurrentQueue<AudioChunk> chunks)
+    {
+        var total = 0;
+        foreach (var chunk in chunks)
+        {
+            total += chunk.Samples.Length;
+        }
+        if (total == 0)
+        {
+            return [];
+        }
+        var result = new float[total];
+        var idx = 0;
+        foreach (var chunk in chunks)
+        {
+            Array.Copy(chunk.Samples, 0, result, idx, chunk.Samples.Length);
+            idx += chunk.Samples.Length;
+        }
+        return result;
     }
 
     public async Task CancelAsync(Guid sessionId, CancellationToken ct)
@@ -560,6 +603,7 @@ public sealed class DictationSessionManager : IDictationSessionManager
                 SingleReader = false,
                 SingleWriter = true
             });
+            AccumulatedChunks = new ConcurrentQueue<AudioChunk>();
             Cts = new CancellationTokenSource();
             TranscriptionTask = Task.CompletedTask;
             LastPartialText = string.Empty;
@@ -581,6 +625,7 @@ public sealed class DictationSessionManager : IDictationSessionManager
         public ChannelReader<AudioChunk> AudioReader { get; }
         public ChannelWriter<AudioChunk> AudioWriter { get; }
         public Channel<PartialTranscript> Partials { get; }
+        public ConcurrentQueue<AudioChunk> AccumulatedChunks { get; }
         public CancellationTokenSource Cts { get; }
         public Task TranscriptionTask { get; set; }
         public string LastPartialText { get; set; }

--- a/backend/src/Mozgoslav.Infrastructure/Services/WhisperNetTranscriptionService.cs
+++ b/backend/src/Mozgoslav.Infrastructure/Services/WhisperNetTranscriptionService.cs
@@ -119,77 +119,108 @@ public sealed class WhisperNetTranscriptionService
         var maxBufferSamples = StreamSampleRate * StreamMaxBufferSeconds;
         var committed = new StringBuilder();
 
-        await foreach (var chunk in chunks.WithCancellation(ct))
+        var chunksReceived = 0;
+        var chunksPassedVad = 0;
+        var partialsEmitted = 0;
+        double peakRms = 0;
+
+        try
         {
-            if (chunk.SampleRate != StreamSampleRate)
+            await foreach (var chunk in chunks.WithCancellation(ct))
             {
-                throw new InvalidOperationException(
-                    $"Streaming expects {StreamSampleRate} Hz mono samples, got {chunk.SampleRate} Hz");
-            }
-
-            if (!_vad.ContainsSpeech(chunk))
-            {
-                continue;
-            }
-
-            buffer.AddRange(chunk.Samples);
-            samplesSinceLastEmit += chunk.Samples.Length;
-            totalSamples += chunk.Samples.Length;
-
-            if (buffer.Count > maxBufferSamples)
-            {
-                var snapshot = buffer.ToArray();
-                var committedText = await TranscribeBufferAsync(whisperFactory, snapshot, language, initialPrompt, ct);
-                if (!string.IsNullOrWhiteSpace(committedText))
+                chunksReceived++;
+                if (chunk.SampleRate != StreamSampleRate)
                 {
-                    if (committed.Length > 0) committed.Append(' ');
-                    committed.Append(committedText.Trim());
+                    throw new InvalidOperationException(
+                        $"Streaming expects {StreamSampleRate} Hz mono samples, got {chunk.SampleRate} Hz");
                 }
-                buffer.Clear();
-                samplesSinceLastEmit = 0;
-                _logger.LogInformation(
-                    "Stream commit: buffer cap reached, committed chars={Chars}, total committed={TotalChars}",
-                    committedText?.Length ?? 0, committed.Length);
-                continue;
+
+                if (chunk.Samples.Length > 0)
+                {
+                    double sum = 0;
+                    for (int i = 0; i < chunk.Samples.Length; i++)
+                    {
+                        var s = chunk.Samples[i];
+                        sum += s * s;
+                    }
+                    var rms = Math.Sqrt(sum / chunk.Samples.Length);
+                    if (rms > peakRms) peakRms = rms;
+                }
+
+                if (!_vad.ContainsSpeech(chunk))
+                {
+                    continue;
+                }
+                chunksPassedVad++;
+
+                buffer.AddRange(chunk.Samples);
+                samplesSinceLastEmit += chunk.Samples.Length;
+                totalSamples += chunk.Samples.Length;
+
+                if (buffer.Count > maxBufferSamples)
+                {
+                    var snapshot = buffer.ToArray();
+                    var committedText = await TranscribeBufferAsync(whisperFactory, snapshot, language, initialPrompt, ct);
+                    if (!string.IsNullOrWhiteSpace(committedText))
+                    {
+                        if (committed.Length > 0) committed.Append(' ');
+                        committed.Append(committedText.Trim());
+                    }
+                    buffer.Clear();
+                    samplesSinceLastEmit = 0;
+                    _logger.LogInformation(
+                        "Stream commit: buffer cap reached, committed chars={Chars}, total committed={TotalChars}",
+                        committedText?.Length ?? 0, committed.Length);
+                    continue;
+                }
+
+                if (samplesSinceLastEmit >= windowSamples)
+                {
+                    samplesSinceLastEmit = 0;
+                    _ = _cache.TryGetValue(CacheKey, out _);
+                    var snapshot = buffer.ToArray();
+                    var text = await TranscribeBufferAsync(whisperFactory, snapshot, language, initialPrompt, ct);
+                    if (!string.IsNullOrWhiteSpace(text) || committed.Length > 0)
+                    {
+                        var emitted = committed.Length > 0
+                            ? $"{committed} {text}".Trim()
+                            : text;
+                        partialsEmitted++;
+                        yield return new PartialTranscript(
+                            Text: emitted,
+                            Timestamp: TimeSpan.FromSeconds((double)totalSamples / StreamSampleRate));
+                    }
+                }
             }
 
-            if (samplesSinceLastEmit >= windowSamples)
+            if (buffer.Count > 0)
             {
-                samplesSinceLastEmit = 0;
-                _ = _cache.TryGetValue(CacheKey, out _);
-                var snapshot = buffer.ToArray();
-                var text = await TranscribeBufferAsync(whisperFactory, snapshot, language, initialPrompt, ct);
+                var tail = buffer.ToArray();
+                var text = await TranscribeBufferAsync(whisperFactory, tail, language, initialPrompt, ct);
                 if (!string.IsNullOrWhiteSpace(text) || committed.Length > 0)
                 {
                     var emitted = committed.Length > 0
                         ? $"{committed} {text}".Trim()
                         : text;
+                    partialsEmitted++;
                     yield return new PartialTranscript(
                         Text: emitted,
                         Timestamp: TimeSpan.FromSeconds((double)totalSamples / StreamSampleRate));
                 }
             }
-        }
-
-        if (buffer.Count > 0)
-        {
-            var tail = buffer.ToArray();
-            var text = await TranscribeBufferAsync(whisperFactory, tail, language, initialPrompt, ct);
-            if (!string.IsNullOrWhiteSpace(text) || committed.Length > 0)
+            else if (committed.Length > 0)
             {
-                var emitted = committed.Length > 0
-                    ? $"{committed} {text}".Trim()
-                    : text;
+                partialsEmitted++;
                 yield return new PartialTranscript(
-                    Text: emitted,
+                    Text: committed.ToString().Trim(),
                     Timestamp: TimeSpan.FromSeconds((double)totalSamples / StreamSampleRate));
             }
         }
-        else if (committed.Length > 0)
+        finally
         {
-            yield return new PartialTranscript(
-                Text: committed.ToString().Trim(),
-                Timestamp: TimeSpan.FromSeconds((double)totalSamples / StreamSampleRate));
+            _logger.LogInformation(
+                "Streaming transcription ended: chunks={ChunksReceived} vadPassed={ChunksPassedVad} partials={PartialsEmitted} peakRms={PeakRms:F5} committedChars={CommittedChars}",
+                chunksReceived, chunksPassedVad, partialsEmitted, peakRms, committed.Length);
         }
     }
 
@@ -227,6 +258,45 @@ public sealed class WhisperNetTranscriptionService
             disposable.Dispose();
         }
 #pragma warning restore IDISP007
+    }
+
+    public async Task<string> TranscribeSamplesAsync(
+        float[] samples,
+        string language,
+        string? initialPrompt,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(samples);
+        if (samples.Length == 0)
+        {
+            _logger.LogInformation("One-shot dictation transcription skipped: 0 samples");
+            return string.Empty;
+        }
+
+        _logger.LogInformation(
+            "One-shot dictation transcription start: {Samples} samples (~{DurationMs} ms)",
+            samples.Length, samples.Length * 1000L / StreamSampleRate);
+
+#pragma warning disable IDISP001
+        var whisperFactory = GetOrCreateFactory();
+#pragma warning restore IDISP001
+        _ = _cache.TryGetValue(CacheKey, out _);
+
+        await using var processor = BuildProcessor(whisperFactory, language, initialPrompt, BeamSize);
+
+        var parts = new List<string>();
+        await foreach (var segment in processor.ProcessAsync(samples, ct).WithCancellation(ct))
+        {
+            var text = segment.Text?.Trim();
+            if (!string.IsNullOrEmpty(text))
+            {
+                parts.Add(text);
+            }
+        }
+
+        var result = string.Join(" ", parts).Trim();
+        _logger.LogInformation("One-shot dictation transcription done: {Chars} chars", result.Length);
+        return result;
     }
 
     private async Task<string> TranscribeBufferAsync(

--- a/backend/tests/Mozgoslav.Tests.Integration/DictationCrashRecoveryTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/DictationCrashRecoveryTests.cs
@@ -271,5 +271,11 @@ public sealed class DictationCrashRecoveryTests
             }
             yield break;
         }
+
+        public Task<string> TranscribeSamplesAsync(
+            float[] samples,
+            string language,
+            string? initialPrompt,
+            CancellationToken ct) => Task.FromResult(string.Empty);
     }
 }

--- a/backend/tests/Mozgoslav.Tests.Integration/DictationPushWebmOpusTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/DictationPushWebmOpusTests.cs
@@ -132,6 +132,7 @@ public sealed class DictationPushWebmOpusTests
     private sealed class CapturingStreamingService : IStreamingTranscriptionService
     {
         public List<AudioChunk> ReceivedChunks { get; } = [];
+        public List<float> ReceivedSamples { get; } = [];
 
         public async IAsyncEnumerable<PartialTranscript> TranscribeStreamAsync(
             IAsyncEnumerable<AudioChunk> chunks,
@@ -144,6 +145,16 @@ public sealed class DictationPushWebmOpusTests
                 ReceivedChunks.Add(chunk);
             }
             yield break;
+        }
+
+        public Task<string> TranscribeSamplesAsync(
+            float[] samples,
+            string language,
+            string? initialPrompt,
+            CancellationToken ct)
+        {
+            ReceivedSamples.AddRange(samples);
+            return Task.FromResult(string.Empty);
         }
     }
 

--- a/backend/tests/Mozgoslav.Tests/Application/DictationRawChunkPipelineTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Application/DictationRawChunkPipelineTests.cs
@@ -154,6 +154,7 @@ public sealed class DictationRawChunkPipelineTests
     private sealed class FakeStreamingService : IStreamingTranscriptionService
     {
         public List<AudioChunk> Chunks { get; } = [];
+        public List<float> SamplesReceived { get; } = [];
 
         public async IAsyncEnumerable<PartialTranscript> TranscribeStreamAsync(
             IAsyncEnumerable<AudioChunk> chunks,
@@ -166,6 +167,16 @@ public sealed class DictationRawChunkPipelineTests
                 Chunks.Add(chunk);
             }
             yield break;
+        }
+
+        public Task<string> TranscribeSamplesAsync(
+            float[] samples,
+            string language,
+            string? initialPrompt,
+            CancellationToken ct)
+        {
+            SamplesReceived.AddRange(samples);
+            return Task.FromResult(string.Empty);
         }
     }
 }

--- a/backend/tests/Mozgoslav.Tests/Application/DictationSessionManagerTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Application/DictationSessionManagerTests.cs
@@ -405,6 +405,7 @@ public sealed class DictationSessionManagerTests
     {
         public List<AudioChunk> Chunks { get; } = [];
         public List<PartialTranscript> Partials { get; } = [];
+        public List<float> SamplesReceived { get; } = [];
         public string? InitialPrompt { get; private set; }
 
         public async IAsyncEnumerable<PartialTranscript> TranscribeStreamAsync(
@@ -422,6 +423,17 @@ public sealed class DictationSessionManagerTests
             {
                 yield return partial;
             }
+        }
+
+        public Task<string> TranscribeSamplesAsync(
+            float[] samples,
+            string language,
+            string? initialPrompt,
+            CancellationToken ct)
+        {
+            InitialPrompt = initialPrompt;
+            SamplesReceived.AddRange(samples);
+            return Task.FromResult(Partials.LastOrDefault()?.Text ?? string.Empty);
         }
     }
 

--- a/backend/tests/Mozgoslav.Tests/Application/DictationSessionSourceTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Application/DictationSessionSourceTests.cs
@@ -103,5 +103,11 @@ public sealed class DictationSessionSourceTests
             }
             yield break;
         }
+
+        public Task<string> TranscribeSamplesAsync(
+            float[] samples,
+            string language,
+            string? initialPrompt,
+            CancellationToken ct) => Task.FromResult(string.Empty);
     }
 }


### PR DESCRIPTION
Финальный текст диктовки теперь делается одним прогоном whisper beam=5 на всём буфере сессии, как у всех шиппинг-инструментов на macOS (Superwhisper, MacWhisper, Voxtype, TypeWhisper, LocalWhisper, MisterWhisper). Старый путь гнал финал через greedy (beam=1) 300 ms sliding window с VAD-гейтом — на коротких сессиях регулярно 0 chars. Streaming-путь сохранён best-effort для live-preview в overlay, но его результат больше не решает финал. dotnet build -maxcpucount:1 зелёный. Бекенд-тесты не гонял по твоему решению.