### PR TITLE
fix(dictation): always inject transcript at cursor, regardless of mode

### DIFF
--- a/frontend/electron/dictation/DictationOrchestrator.ts
+++ b/frontend/electron/dictation/DictationOrchestrator.ts
@@ -74,6 +74,13 @@ export class DictationOrchestrator {
         }
     }
 
+    async injectText(
+        text: string,
+        mode: "auto" | "cgevent" | "accessibility",
+    ): Promise<void> {
+        await this.helper.injectText(text, mode);
+    }
+
     async configurePushToTalk(options: {
         mouseButton: number | null;
         keyboardAccelerator: string | null;

--- a/frontend/electron/main.ts
+++ b/frontend/electron/main.ts
@@ -271,6 +271,17 @@ app.whenReady().then(async () => {
         return recordingHelper.stopFileCapture(sessionId);
     });
 
+    ipcMain.handle(
+        "dictation:inject",
+        async (_event, text: string, mode: "auto" | "cgevent" | "accessibility") => {
+            if (!text) return;
+            if (!dictationOrchestrator) {
+                throw new Error("Dictation orchestrator is not ready.");
+            }
+            await dictationOrchestrator.injectText(text, mode);
+        },
+    );
+
     ipcMain.handle("sync:listConflicts", async (_event, folderPath: string) => {
         try {
             const walked = await walkForConflicts(folderPath);

--- a/frontend/electron/preload.ts
+++ b/frontend/electron/preload.ts
@@ -53,6 +53,16 @@ export interface MozgoslavBridge {
      */
     startNativeRecording?: (outputPath: string) => Promise<{ sessionId: string }>;
     stopNativeRecording?: (sessionId: string) => Promise<{ path: string; durationMs: number }>;
+    /**
+     * Writes the given text into whichever app currently owns keyboard focus
+     * via the native dictation helper. Used by the toggle-mode dictation path
+     * so that every successful transcription ends up at the caret, matching
+     * push-to-talk behavior.
+     */
+    dictationInject?: (
+        text: string,
+        mode: "auto" | "cgevent" | "accessibility",
+    ) => Promise<void>;
 }
 
 export interface DictationOverlayState {
@@ -91,6 +101,8 @@ const bridge: MozgoslavBridge = {
         ipcRenderer.invoke("record:start", outputPath),
     stopNativeRecording: (sessionId) =>
         ipcRenderer.invoke("record:stop", sessionId),
+    dictationInject: (text, mode) =>
+        ipcRenderer.invoke("dictation:inject", text, mode),
 };
 
 const overlayBridge: MozgoslavOverlayBridge = {

--- a/frontend/src/api/DictationApi.ts
+++ b/frontend/src/api/DictationApi.ts
@@ -10,7 +10,9 @@ export interface StartDictationResult {
 }
 
 export interface StopDictationResult {
-    readonly transcript: string;
+    readonly rawText: string;
+    readonly polishedText: string;
+    readonly durationMs: number;
 }
 
 export interface AudioCapabilities {

--- a/frontend/src/features/Dashboard/Dashboard.tsx
+++ b/frontend/src/features/Dashboard/Dashboard.tsx
@@ -193,7 +193,14 @@ const Dashboard: FC = () => {
 
             try {
                 const result = await dictationApi.stop(active.sessionId);
-                setTranscript(result.transcript);
+                setTranscript(result.polishedText);
+                if (!active.persistOnStop && result.polishedText) {
+                    try {
+                        await window.mozgoslav?.dictationInject?.(result.polishedText, "auto");
+                    } catch (injectErr) {
+                        console.warn("[dictation] inject failed:", injectErr);
+                    }
+                }
             } catch (err) {
                 toast.error(err instanceof Error ? err.message : String(err));
             }

--- a/frontend/src/features/Dashboard/__tests__/Dashboard.test.tsx
+++ b/frontend/src/features/Dashboard/__tests__/Dashboard.test.tsx
@@ -141,7 +141,9 @@ describe("Dashboard record button (BC-004 / Bug 3)", () => {
         installMocks();
         api.startDictation.mockResolvedValue({sessionId: "sess-2"});
         api.stopDictation.mockResolvedValue({
-            transcript: "Hello world",
+            rawText: "Hello world",
+            polishedText: "Hello world",
+            durationMs: 1000,
         });
 
         renderDashboard();


### PR DESCRIPTION
Toggle-путь диктовки получал транскрипт с бекенда, но никогда не вызывал helper.injectText. Комментарий на ActiveSession.persistOnStop обещал инжект, но call-site отсутствовал. Чиню: через preload-бридж window.mozgoslav.dictationInject(text, mode) и новый ipcMain.handle("dictation:inject") рендер-сторона теперь зовёт помощника после /stop, когда persistOnStop=false. Ручная кнопка Записать (persistOnStop=true) не меняет поведение. Попутно фикс DTO drift: StopDictationResult был {transcript} в клиенте, бекенд возвращает {rawText, polishedText, durationMs} — выровняно. Тесты не гонял.