### PR TITLE
fix: stale action toast re-fires on tab remount (notifications slice)

### DIFF
--- a/docs/agent-tasks/fix-stale-action-feedback.md
+++ b/docs/agent-tasks/fix-stale-action-feedback.md
@@ -1,0 +1,588 @@
+# Agent task — fix stale action-result feedback on tab remount
+
+**Audience:** an implementation agent (developer role). Not a human ADR. Treat this file as a linear checklist: execute top-to-bottom, commit per phase, do not skip phases.
+
+**Status:** authoritative. This file is the single source of truth for the fix. If you discover something that contradicts it, STOP and report — do not improvise.
+
+---
+
+## 0. Meta
+
+**Owner:** rybalchenko
+**Target branch:** `rybalchenko/fix-stale-action-feedback-2026-04-22` — created from `origin/main`.
+**Commit mode:** commit per phase (phase numbers match commit subjects, see §Commit schema).
+**No push. No MR.** Local commits only, unless the user instructs otherwise.
+**Breaking changes are allowed** — Mozgoslav is pre-production, no external clients.
+**Quality bar:** best-practice only. Refuse mediocre work. If a phase cannot meet the bar, stop and report — do not ship a compromise.
+**No scope expansion.** Do not refactor unrelated code. Do not touch `.archive/`. Do not rewrite ADRs. Do not migrate other slices «while you're at it».
+**2-strike rule:** if the same step fails twice, stop, capture the full context (error, files touched, commands run), report, wait. Do not silent-retry a third time.
+**Autonomy:** do not ask clarifying questions back. If something is ambiguous, pick the best default consistent with this brief and flag it as UNVERIFIED in the phase report.
+**Always read first.** Before writing any file, read the existing code it touches. Before creating any symbol, `grep` for duplicates.
+**Commands:** every `dotnet` invocation MUST include `-maxcpucount:1` (sandbox CPU rule from root `CLAUDE.md`). Frontend commands run from `frontend/`.
+
+---
+
+## 1. Problem statement (what is being fixed)
+
+Action results that should be one-shot events are stored as persistent fields in redux slices. Components read those fields through selectors and fire toasts inside `useEffect` hooks keyed by the field. When React Router unmounts the screen on tab switch and remounts on return, the selector still returns the same non-null value, the effect's dependency compare is identical, and the toast re-fires — as if the user just clicked the button.
+
+### 1.1 Affected flows (source of the bug report)
+
+| # | Component | Dispatched action | Persistent state field | `useEffect` location | Toast |
+|---|---|---|---|---|---|
+| 1 | `frontend/src/features/Settings/Settings.tsx` | `checkLlm()` | `settings.llmProbe.ok` | `Settings.tsx:50-57` | `"LLM: ✓"` / `"LLM: ✗"` |
+| 2 | `frontend/src/features/Settings/Settings.tsx` | `loadSettings()` / `saveSettings()` failure paths | `settings.error` | `Settings.tsx:46-48` | `t("…error payload")` |
+| 3 | `frontend/src/features/Obsidian/Obsidian.tsx` | `applyLayout()` | `obsidian.lastApplyLayoutReport` | `Obsidian.tsx:69-78` | `t("obsidian.applyLayoutSuccess", …)` |
+| 4 | `frontend/src/features/Obsidian/Obsidian.tsx` | `bulkExport()` | `obsidian.lastBulkExportReport` | `Obsidian.tsx:63-67` | `t("obsidian.syncAllSuccess", …)` |
+| 5 | `frontend/src/features/Obsidian/Obsidian.tsx` | `setupObsidian()` | `obsidian.lastSetupReport` | `Obsidian.tsx:80-86` | `t("obsidian.setupSuccess", …)` |
+| 6 | `frontend/src/features/Obsidian/Obsidian.tsx` | any failure path | `obsidian.error` | `Obsidian.tsx:42-44` | `toast.error(error)` |
+
+All six read from redux state whose lifetime is the session. None of them reset on component mount. Same root cause, same fix.
+
+### 1.2 What is explicitly NOT in scope
+
+- **`toast.success(t("settings.savedToast"))` at `Settings.tsx:64`** — fired from an event handler (`save()`), not from a selector-driven `useEffect`. Not stale. **Do not touch it.**
+- Any other `toast.*` call in the codebase that is fired from an event handler (direct user click, form submit handler) — those are already one-shot and correct.
+- Slices that already never emit toasts on SUCCESS (`sync`, `recording`, `profiles`, `jobs`, `rag`, `onboarding`). **Do not migrate them.** Scope creep is a defect.
+- `.archive/` — never touch.
+- Backend (.NET). No API changes.
+- Electron main/preload. No changes.
+- i18n resource files — unless you need to add a key for an error-translation helper (see §2.4). If you add one, add the key to **both** `src/locales/ru.json` and `src/locales/en.json`.
+- Existing ADRs under `docs/adr/`.
+
+---
+
+## 2. Tech decisions (fixed — do not relitigate)
+
+| Concern | Decision | Rationale |
+|---|---|---|
+| Primitive for user-facing one-shot events | **Transient notification actions.** A pair of redux action types per kind (`NOTIFY_SUCCESS`, `NOTIFY_ERROR`, `NOTIFY_WARNING`, `NOTIFY_INFO`), carrying `{ messageKey: string; params?: Record<string, unknown> }`. A single root-level saga converts them to `toast[kind](...)`. | Matches the canonical frontend pattern (cf. `frontend-scenarios-v2`'s effector `NotificationModel.add/remove/clear` used across all features). Event-like UI outputs emitted at the event, not observed from state. |
+| Slice state for notifications | **None.** `react-toastify`'s `ToastContainer` already is the transient queue (`autoClose={3500}`, `newestOnTop`, position). Duplicating it in redux buys nothing. | Less state = fewer bugs. Keeps the slice purely action-and-saga. |
+| Location | `frontend/src/store/slices/notifications/` — `actions.ts`, `saga/notificationsSaga.ts`, `index.ts`. No `reducer.ts`, no `mutations.ts`, no `selectors.ts`, no `types.ts`. | Consistent with team slice convention, but makes the slicelessness explicit. |
+| Emission site | Only inside **sagas** (success and failure paths) and **event handlers** that have direct user context (e.g. validation errors before dispatch). NOT inside components' `useEffect`. | Drives the rule: components don't read a flag and fire a toast; sagas put a one-shot action. |
+| Translation | Saga puts `messageKey` (string) + `params` (plain JSON). Listener saga calls `i18next.t(messageKey, params)` imperatively via the default `i18n` instance (already initialized in `frontend/src/i18n/index.ts`). | Sagas stay testable without a React tree. One coupling point between redux and i18next, inside `notificationsSaga.ts`. |
+| Toast lib coupling | Isolated to `notificationsSaga.ts`. No other file in `frontend/src/store/` imports `react-toastify` after Phase 6. | Swap of toast lib later is a one-file change. Also helps saga tests — domain sagas never touch `toast`. |
+| Error strings (fields like `settings.error` / `obsidian.error`) | Deleted from state. FAILURE sagas dispatch `notifyError({ messageKey, params })` with an appropriate key. If the error payload is a raw string from the backend (no key), use a generic key like `errors.genericErrorWithMessage` with a `{message}` param (add it to both locale files if missing — smallest possible addition). | Pattern-symmetric with success path. No hidden «error flash on remount». |
+| Hardcoded strings in scope #1 | `"LLM: ✓"` / `"LLM: ✗"` are currently hardcoded. Replace with i18n keys `settings.llmCheckSuccessToast` / `settings.llmCheckFailureToast` — add to both `ru.json` and `en.json`. This is the ONE locale-file addition explicitly permitted. | We are deleting the call-site anyway; replacing two hardcoded strings with proper keys has zero extra cost and is a correctness improvement inside the same diff. |
+| Typing of `messageKey` | `string` (not a template-literal union of known keys). `i18next.t` falls back to the key if missing, which is acceptable during migration. | Strong typing of translation keys is a separate concern; out of scope. |
+| Tests | Every phase adds/updates saga tests using `redux-saga-test-plan` to assert: (a) the SUCCESS or FAILURE path `put`s the corresponding `notifySuccess` / `notifyError` action with the correct `messageKey` and `params`; (b) the SUCCESS path no longer `put`s a `SET_X_REPORT` action. One component test (React Testing Library) asserts no `useEffect`-driven toast remains in the migrated feature — i.e. mounting with pre-populated slice state does NOT call `toast.*`. | Locks the fix at the primitive level. |
+| Code style | One class/module per file. `sealed`/`internal` — N/A (TS). No default export for utilities; default export for React components (team convention, root CLAUDE.md). | Existing convention. |
+| No comments | Per project rule (`CLAUDE.md`: «NO COMMENTS!»). | Existing convention. |
+
+Anything not in this table: pick the simplest thing that works and flag UNVERIFIED.
+
+---
+
+## 3. Pre-flight
+
+```bash
+cd /home/coder/workspace/mozgoslav-main
+git fetch origin main
+git checkout main
+git reset --hard origin/main
+git status                    # MUST be clean
+git checkout -b rybalchenko/fix-stale-action-feedback-2026-04-22
+```
+
+Read (do not skip):
+
+- Root `CLAUDE.md` (authoritative on conventions; `.archive/` invisible)
+- `frontend/CLAUDE.md` (frontend conventions; slice layout)
+- `frontend/src/store/rootSaga.ts` — you will add one `fork(watchNotificationsSagas)` line
+- `frontend/src/i18n/index.ts` — confirm the imperative `i18n.t(key, params)` API you will use from the saga
+- `frontend/src/main.tsx` — confirm `<ToastContainer/>` is mounted (do NOT modify its props)
+- `frontend/src/store/slices/recording/` — the canonical slice reference (structure template); your new slice is smaller but follows naming
+- Each source file you are migrating in its phase (listed per phase below)
+- `frontend-scenarios-v2/src/models/notification/index.ts` + `src/shared/ui/NotificationStack/*` (cloned at `/home/coder/workspace/frontend-scenarios-v2/` if present) — reference implementation to keep in mind when reasoning about the target shape. You are NOT porting effector code; you are matching the primitive.
+
+If any of those reads reveal a material deviation from this document (e.g. an additional `last*Report` field added after 2026-04-22, or a new `useEffect(..., [stateField])` pattern somewhere not listed in §1.1), STOP and report — do not silently extend scope.
+
+---
+
+## 4. Phase 0 — notifications slice scaffold
+
+Commit subject: `feat(notifications): phase 0 — scaffold slice-less notifications saga`
+
+### 4.1 New files
+
+Create `frontend/src/store/slices/notifications/actions.ts`:
+
+```ts
+export const NOTIFY_SUCCESS = "notifications/NOTIFY_SUCCESS" as const;
+export const NOTIFY_ERROR = "notifications/NOTIFY_ERROR" as const;
+export const NOTIFY_WARNING = "notifications/NOTIFY_WARNING" as const;
+export const NOTIFY_INFO = "notifications/NOTIFY_INFO" as const;
+
+export interface NotifyPayload {
+    readonly messageKey: string;
+    readonly params?: Record<string, unknown>;
+}
+
+export const notifySuccess = (payload: NotifyPayload) =>
+    ({type: NOTIFY_SUCCESS, payload} as const);
+export const notifyError = (payload: NotifyPayload) =>
+    ({type: NOTIFY_ERROR, payload} as const);
+export const notifyWarning = (payload: NotifyPayload) =>
+    ({type: NOTIFY_WARNING, payload} as const);
+export const notifyInfo = (payload: NotifyPayload) =>
+    ({type: NOTIFY_INFO, payload} as const);
+
+export type NotificationAction =
+    | ReturnType<typeof notifySuccess>
+    | ReturnType<typeof notifyError>
+    | ReturnType<typeof notifyWarning>
+    | ReturnType<typeof notifyInfo>;
+```
+
+Create `frontend/src/store/slices/notifications/saga/notificationsSaga.ts`:
+
+```ts
+import {takeEvery} from "redux-saga/effects";
+import {toast} from "react-toastify";
+import i18n from "../../../../i18n";
+import {
+    NOTIFY_SUCCESS,
+    NOTIFY_ERROR,
+    NOTIFY_WARNING,
+    NOTIFY_INFO,
+    type NotificationAction,
+} from "../actions";
+
+function showToast(action: NotificationAction): void {
+    const message = i18n.t(action.payload.messageKey, action.payload.params ?? {}) as string;
+    switch (action.type) {
+        case NOTIFY_SUCCESS:
+            toast.success(message);
+            return;
+        case NOTIFY_ERROR:
+            toast.error(message);
+            return;
+        case NOTIFY_WARNING:
+            toast.warning(message);
+            return;
+        case NOTIFY_INFO:
+            toast.info(message);
+            return;
+    }
+}
+
+export function* watchNotificationsSagas() {
+    yield takeEvery(
+        [NOTIFY_SUCCESS, NOTIFY_ERROR, NOTIFY_WARNING, NOTIFY_INFO],
+        showToast,
+    );
+}
+```
+
+Create `frontend/src/store/slices/notifications/index.ts`:
+
+```ts
+export * from "./actions";
+export {watchNotificationsSagas} from "./saga/notificationsSaga";
+```
+
+### 4.2 Root saga registration
+
+In `frontend/src/store/rootSaga.ts` — add:
+
+- One import: `import {watchNotificationsSagas} from "./slices/notifications";`
+- One entry inside the `all([...])`: `fork(watchNotificationsSagas),`
+
+Place the fork BEFORE any feature watcher that will `put(notify*)` (to avoid an undefined-ordering edge where a synchronous saga on boot could emit before the listener is attached). Top of the list is safe.
+
+### 4.3 Tests
+
+Add `frontend/src/store/slices/notifications/__tests__/notificationsSaga.test.ts`:
+
+- Use `redux-saga-test-plan`'s `expectSaga`.
+- Mock `react-toastify` (`jest.mock("react-toastify", () => ({toast: {success: jest.fn(), error: jest.fn(), warning: jest.fn(), info: jest.fn()}}))`).
+- Mock `i18n.t` to return `${key}:${JSON.stringify(params)}`.
+- One case per action type: dispatch the action, assert the corresponding `toast.*` was called with the translated string.
+
+### 4.4 Verification
+
+```bash
+cd frontend
+npm run typecheck
+npm run lint
+npm test -- notifications
+```
+
+Must be green.
+
+**Phase 0 exit criteria:** the four actions exist and are typed; dispatching any of them from anywhere results in a single toast; tests green.
+
+---
+
+## 5. Phase 1 — migrate LLM connection check
+
+Commit subject: `fix(settings): phase 1 — emit LLM check toast via notifications`
+
+### 5.1 Read first
+
+- `frontend/src/features/Settings/Settings.tsx`
+- `frontend/src/store/slices/settings/saga/checkLlmSaga.ts`
+- `frontend/src/store/slices/settings/actions.ts`
+- `frontend/src/store/slices/settings/reducer.ts`
+- `frontend/src/store/slices/settings/mutations.ts`
+- `frontend/src/store/slices/settings/selectors.ts`
+- `frontend/src/store/slices/settings/types.ts`
+- `frontend/src/features/Settings/Settings.container.ts`
+
+### 5.2 Locale additions
+
+Add to **both** `src/locales/ru.json` and `src/locales/en.json` under the existing `settings` namespace:
+
+- `settings.llmCheckSuccessToast` — ru: `"LLM: соединение установлено"`, en: `"LLM: connection OK"`.
+- `settings.llmCheckFailureToast` — ru: `"LLM: соединение не установлено"`, en: `"LLM: connection failed"`.
+
+(These replace the hardcoded `"LLM: ✓"` / `"LLM: ✗"`.)
+
+### 5.3 Saga change
+
+In `frontend/src/store/slices/settings/saga/checkLlmSaga.ts`:
+
+- After determining `ok: boolean` from the API response, `yield put(ok ? notifySuccess({messageKey: "settings.llmCheckSuccessToast"}) : notifyWarning({messageKey: "settings.llmCheckFailureToast"}));`
+- **Delete** the `yield put(checkLlmResult({ok}))` line AND the `CHECK_LLM_RESULT` action type AND the `settleLlmProbe` mutation AND the reducer branch handling `CHECK_LLM_RESULT` AND the `llmProbe.ok` field in `SettingsState` AND the `selectLlmProbe` selector AND the container mapping of `llmProbe` to props.
+
+However — `llmProbe.probing` is still needed for the button's `isLoading` state. Keep it. Reduce `llmProbe` to `{probing: boolean}`:
+
+- `types.ts`: `llmProbe: {probing: boolean}` (initial `{probing: false}`).
+- `mutations.ts`: keep `markLlmProbing`; delete `settleLlmProbe`.
+- Reducer: `CHECK_LLM` → `markLlmProbing`; new terminator `CHECK_LLM_DONE` (action type) — resets `probing: false`. Saga puts `CHECK_LLM_DONE` at the end of the flow (both success and error paths, in `finally`).
+- `selectors.ts`: keep `selectLlmProbe` but narrowed; or introduce `selectLlmProbing` (boolean). Whichever is fewer LOC — prefer removing `selectLlmProbe` in favour of `selectLlmProbing`.
+
+### 5.4 Component change
+
+In `frontend/src/features/Settings/Settings.tsx`:
+
+- Delete the entire `useEffect(() => { if (llmProbe.ok === null || llmProbe.probing) return; … }, [llmProbe]);` block at lines 50-57.
+- Remove `llmProbe` from the destructured props; replace with `isLlmProbing` (boolean).
+- Wire the button's disabled/spinner state to `isLlmProbing` (match the existing `isSaving` / `isLoading` pattern around it).
+- Container `mapStateToProps`: replace `llmProbe: selectLlmProbe(state)` with `isLlmProbing: selectLlmProbing(state)`.
+
+### 5.5 Tests
+
+- Update `checkLlmSaga.test.ts` (or create if missing):
+  - Success path: API returns `ok: true` → `put(notifySuccess({messageKey: "settings.llmCheckSuccessToast"}))` and `put({type: CHECK_LLM_DONE})`. Assert NO `CHECK_LLM_RESULT` put.
+  - Failure path (API throws or `ok: false`): `put(notifyWarning({messageKey: "settings.llmCheckFailureToast"}))` + `CHECK_LLM_DONE`.
+- Component-level test (Settings): render with `llmProbe: {probing: false}` in initial store (no `ok` field). Assert `toast.*` was not called. Previously this is exactly what re-fired on remount.
+
+### 5.6 Verify and commit
+
+```bash
+cd frontend && npm run typecheck && npm run lint && npm test
+git add -A && git diff --staged | head -120   # sanity-check the diff
+git commit -m "fix(settings): phase 1 — emit LLM check toast via notifications"
+```
+
+**Phase 1 exit criteria:** clicking «Проверить соединение» still shows the success/failure toast once; switching tabs and returning to Settings does NOT re-fire the toast; tests green.
+
+---
+
+## 6. Phase 2 — migrate Settings error
+
+Commit subject: `fix(settings): phase 2 — emit load/save errors via notifications`
+
+### 6.1 Scope
+
+- `LOAD_SETTINGS_FAILURE` — saga `frontend/src/store/slices/settings/saga/loadSettingsSaga.ts` (or equivalent).
+- `SAVE_SETTINGS_FAILURE` — saga `frontend/src/store/slices/settings/saga/saveSettingsSaga.ts` (or equivalent).
+- Component useEffect `Settings.tsx:46-48` (`if (error) toast.error(error);`).
+- `settings.error` field.
+
+### 6.2 Error message mapping
+
+Add ONE key to both locale files (under a new or existing `errors` namespace — check what exists first; reuse if there is one):
+
+- `errors.genericErrorWithMessage` — ru: `"Ошибка: {{message}}"`, en: `"Error: {{message}}"`.
+
+### 6.3 Changes
+
+- Both FAILURE sagas: `yield put(notifyError({messageKey: "errors.genericErrorWithMessage", params: {message: extractMessage(err)}}))`. Implement `extractMessage(err: unknown): string` inline (small helper; ≤ 6 lines). Do NOT add a package.
+- Reducer: remove `error: typed.payload` from `LOAD_SETTINGS_FAILURE` / `SAVE_SETTINGS_FAILURE` branches. They still flip the `isLoading` / `isSaving` flags back to `false`, so `error: null` is no longer relevant — drop the `error` field entirely.
+- `types.ts`: remove `error: string | null` from `SettingsState`.
+- `selectors.ts`: remove `selectSettingsError` if it exists.
+- Container: drop `error` prop.
+- Component: delete `error` from destructured props; delete the useEffect at 46-48.
+
+### 6.4 Tests
+
+- Saga tests for both FAILURE paths — `put(notifyError({messageKey: "errors.genericErrorWithMessage", params: {message: …}}))`.
+- Component test: mount Settings with initial error-free state; no `toast.error` called. Mount after a failure was dispatched (simulate via store) — still no `toast.error` on re-mount (the toast was fired at the saga level, not on state observation).
+
+### 6.5 Verify and commit
+
+Same as Phase 1.6.
+
+**Phase 2 exit criteria:** load/save settings errors still appear as toasts once; no re-fire on tab switch; tests green.
+
+---
+
+## 7. Phase 3 — migrate Obsidian applyLayout
+
+Commit subject: `fix(obsidian): phase 3 — emit applyLayout result via notifications`
+
+### 7.1 Scope
+
+- Saga: `frontend/src/store/slices/obsidian/saga/applyLayoutSaga.ts`.
+- Component useEffect: `Obsidian.tsx:69-78`.
+- State fields: `obsidian.lastApplyLayoutReport`.
+- Actions: `APPLY_LAYOUT_SUCCESS` (the `put` is removed; the action type is deleted unless referenced by tests — check).
+
+### 7.2 Changes
+
+Saga:
+
+```ts
+// after the API call succeeds (report in scope):
+yield put(notifySuccess({
+    messageKey: "obsidian.applyLayoutSuccess",
+    params: {folders: report.createdFolders, notes: report.movedNotes},
+}));
+```
+
+And on failure (same saga's catch / failure path):
+
+```ts
+yield put(notifyError({
+    messageKey: "errors.genericErrorWithMessage",
+    params: {message: extractMessage(err)},
+}));
+```
+
+Remove:
+
+- `APPLY_LAYOUT_SUCCESS` action type + creator (if nothing else imports it).
+- Reducer branch for `APPLY_LAYOUT_SUCCESS` setting `lastApplyLayoutReport`.
+- `lastApplyLayoutReport` field in `ObsidianState.types.ts`.
+- `selectLastApplyLayoutReport` in `selectors.ts`.
+- `lastApplyLayoutReport` from container `mapStateToProps`.
+- The useEffect at `Obsidian.tsx:69-78` and the `lastApplyLayoutReport` prop destructuring.
+
+**Do NOT delete `obsidian.error` yet** — it is still populated by bulkExport and setupObsidian failures. It is deleted in Phase 6.
+**Do NOT delete `isApplyingLayout`** — the button uses it for spinner state.
+**Do NOT delete `beginApplyLayout` mutation** — it sets `isApplyingLayout: true`; still needed.
+
+The FAILURE reducer branch for `applyLayout` currently sets `{isApplyingLayout: false, error: typed.payload}`. Change to `{isApplyingLayout: false, error: null}` (keep field, clear it). The obsolescence of `error` is a Phase 6 concern.
+
+### 7.3 Tests
+
+- Saga: success path asserts `put(notifySuccess({messageKey: "obsidian.applyLayoutSuccess", params: {folders, notes}}))` AND no `put({type: APPLY_LAYOUT_SUCCESS, payload: report})`; failure path asserts `put(notifyError(...))`.
+- Component: mount Obsidian with a non-null `lastApplyLayoutReport` **field removed**; assert `toast.*` not called. (Because the field no longer exists, this is proved by the fact that the useEffect was deleted; the test just re-renders Obsidian twice to simulate remount and asserts `toast.success` mock was not called.)
+
+### 7.4 Verify and commit
+
+Same shape.
+
+**Phase 3 exit criteria:** «Разложить по PARA» still shows its toast once; no re-fire on tab switch.
+
+---
+
+## 8. Phase 4 — migrate Obsidian bulkExport
+
+Commit subject: `fix(obsidian): phase 4 — emit bulkExport result via notifications`
+
+### 8.1 Scope
+
+- Saga `bulkExportSaga.ts`.
+- Component useEffect `Obsidian.tsx:63-67`.
+- State field `lastBulkExportReport`.
+- Selector `selectLastBulkExportReport`.
+
+Translation key already exists: `obsidian.syncAllSuccess` with `{count}` param.
+
+### 8.2 Changes
+
+Mirror Phase 3 exactly — substitute the four proper names. Keep `isBulkExporting` flag; clear `error` on failure (Phase 6 removes the field).
+
+### 8.3 Tests, verification, commit
+
+As Phase 3.
+
+**Phase 4 exit criteria:** sync-all toast one-shot; no re-fire.
+
+---
+
+## 9. Phase 5 — migrate Obsidian setupObsidian
+
+Commit subject: `fix(obsidian): phase 5 — emit setup result via notifications`
+
+### 9.1 Scope
+
+- Saga `setupObsidianSaga.ts`.
+- Component useEffect `Obsidian.tsx:80-86`.
+- State field `lastSetupReport`.
+- Selector `selectLastSetupReport`.
+
+Translation key exists: `obsidian.setupSuccess` with `{created}` param.
+
+### 9.2 Changes
+
+Mirror Phase 3 exactly — substitute the four proper names. Keep `isSetupInProgress`; clear `error` on failure.
+
+### 9.3 Tests, verification, commit
+
+As Phase 3.
+
+**Phase 5 exit criteria:** setup toast one-shot; no re-fire.
+
+---
+
+## 10. Phase 6 — remove obsidian.error field
+
+Commit subject: `fix(obsidian): phase 6 — remove stale error field, all flows use notifications`
+
+### 10.1 Scope
+
+After Phases 3–5, `obsidian.error` is never read (the useEffect at `Obsidian.tsx:42-44` is the only reader, the only writers were the three failure branches — all now emit `notifyError` via saga and set `error: null`). Delete it.
+
+### 10.2 Changes
+
+- Remove `error: string | null` from `ObsidianState`.
+- Remove all `error: null` writes and remaining `error: typed.payload` writes from `reducer.ts` (there should be none of the latter at this point).
+- Delete the useEffect at `Obsidian.tsx:42-44`.
+- Remove `error` from the destructured component props and the container `mapStateToProps`.
+- Remove `selectObsidianError` if it exists.
+
+### 10.3 Tests
+
+- Obsidian component test: remount with simulated prior-failure state → zero `toast.*` calls.
+- Type check only — no new behaviour, removal-only.
+
+### 10.4 Verify and commit
+
+As before.
+
+**Phase 6 exit criteria:** no stale `error` field anywhere in obsidian slice.
+
+---
+
+## 11. Phase 7 — grep sweep + snapshot
+
+Commit subject: `chore(notifications): phase 7 — grep sweep, lint sweep`
+
+### 11.1 Grep contract
+
+From `frontend/`, the following MUST all return zero hits:
+
+```bash
+grep -rn "lastApplyLayoutReport\|lastBulkExportReport\|lastSetupReport" src/
+grep -rn "llmProbe\.ok\|selectLlmProbe\b" src/
+grep -rn "settleLlmProbe\|CHECK_LLM_RESULT" src/
+grep -n "useEffect" src/features/Settings/Settings.tsx src/features/Obsidian/Obsidian.tsx | grep -iE "(toast|error|lastApply|lastBulk|lastSetup|llmProbe)"
+```
+
+`grep -rn "toast\." src/store/` must return hits ONLY inside `src/store/slices/notifications/`.
+
+If any of those return unexpected hits, a prior phase was incomplete — STOP, identify the phase, reopen, fix, re-commit (NOT amending an earlier phase commit; add a fix commit referencing the phase).
+
+### 11.2 Full verification
+
+```bash
+cd frontend
+npm run typecheck
+npm run lint
+npm test
+```
+
+All green.
+
+### 11.3 Manual smoke (UNVERIFIED if cannot run Electron locally)
+
+If able to run the app (`npm run dev` or equivalent — match whatever the project uses; do NOT invent commands):
+
+1. Settings → Проверить соединение → toast. Switch to Queue. Switch back to Settings. No toast. Repeat for failure case.
+2. Obsidian → Разложить по PARA → toast. Switch to Notes. Switch back to Obsidian. No toast.
+3. Obsidian → sync-all → toast. Switch away, switch back. No toast.
+4. Obsidian → setup → toast. Switch away, switch back. No toast.
+
+If the sandbox cannot run the app, mark §11.3 UNVERIFIED in the report and confirm the fix is demonstrated by the RTL component tests instead.
+
+### 11.4 Commit
+
+Only if the grep sweep actually changed a line (e.g. imports cleanup). Otherwise skip this commit and declare the migration complete.
+
+---
+
+## 12. Commit schema
+
+One commit per phase. Conventional Commits. Match `git log --oneline -30` style.
+
+```
+feat(notifications): phase 0 — scaffold slice-less notifications saga
+fix(settings): phase 1 — emit LLM check toast via notifications
+fix(settings): phase 2 — emit load/save errors via notifications
+fix(obsidian): phase 3 — emit applyLayout result via notifications
+fix(obsidian): phase 4 — emit bulkExport result via notifications
+fix(obsidian): phase 5 — emit setup result via notifications
+fix(obsidian): phase 6 — remove stale error field, all flows use notifications
+chore(notifications): phase 7 — grep sweep, lint sweep
+```
+
+Each commit body: list files added / modified / deleted, and the test counts that passed on that phase. Keep it terse. Do NOT include emoji. Do NOT include `Co-Authored-By` unless the user asks.
+
+---
+
+## 13. Verification checklist (enforced at each phase boundary)
+
+Before every commit:
+
+- [ ] `npm run typecheck` green.
+- [ ] `npm run lint` green.
+- [ ] `npm test` green. New tests for this phase exist and cover success + every failure branch touched.
+- [ ] The phase-specific `useEffect` is gone from the component, and the corresponding state field is gone from the slice (Phases 1, 3–6).
+- [ ] No new `toast.*` import outside `src/store/slices/notifications/` (Phases 1+).
+- [ ] No new `useEffect(…, [stateField])` that fires a toast introduced anywhere in migrated components.
+- [ ] No push, no MR, no `main`/`master` touched.
+
+If ANY box is unchecked: phase is not done. Do not commit.
+
+---
+
+## 14. Report
+
+After each phase commit, append to `/home/coder/workspace/mozgoslav-stale-feedback-report-<short-id>.md`:
+
+- Phase number + SHA.
+- Files added / modified / deleted (full paths).
+- Test counts (passed/failed/skipped).
+- Any UNVERIFIED items with reasoning.
+
+After Phase 7: end with a top-level summary: total commits, total LOC delta (added/removed), file count. Path to the report is the last thing you tell the user.
+
+---
+
+## 15. What you MUST NOT do
+
+- NEVER push to remote. No `git push`.
+- NEVER open an MR. No `glab`. No `gh`.
+- NEVER touch `main` or `master`. You work exclusively on `rybalchenko/fix-stale-action-feedback-2026-04-22`.
+- NEVER use `--force`, `--no-verify`, `-c commit.gpgsign=false`, or any hook-skip.
+- NEVER collapse multiple phases into one commit. One phase = one commit. If you need to split a phase, add `phase N.a` / `phase N.b` — never merge.
+- NEVER introduce a new `useEffect` that reads a state field and fires a toast. That is the exact anti-pattern being removed.
+- NEVER import `react-toastify` outside `src/store/slices/notifications/saga/notificationsSaga.ts`. (The existing `ToastContainer` import in `main.tsx` is fine; do not move or rename it.)
+- NEVER migrate a flow that is not in §1.1. This document is the full scope.
+- NEVER expand to other slices («sync could use notifications too…»). Out of scope. If you spot a candidate, add a note to the report; do not fix.
+- NEVER touch `.archive/`, `docs/adr/`, or `backend/`.
+- NEVER ask the user clarifying questions mid-execution. Pick the best default, document as UNVERIFIED.
+- NEVER delete the direct `toast.success(t("settings.savedToast"))` call in `Settings.tsx:64` — it is an event-handler toast and is correct as-is.
+
+---
+
+## 16. Tools & skills
+
+You have full sandbox access. Recommended pattern per phase:
+
+1. READ the saga, reducer, types, selectors, container, component — all of them — before writing.
+2. `grep -rn` for each symbol you plan to delete, to confirm no unexpected consumer exists.
+3. Write tests first (saga test: asserts the `put`; component test: asserts no toast on remount).
+4. Apply the code change.
+5. Run the verification checklist.
+6. Commit.
+
+No per-file build loops. Write the whole phase, then run `npm run typecheck && npm run lint && npm test` once. Rapid per-file cycles waste CPU in the sandbox (1-core cap per `CLAUDE.md`).
+
+If this document conflicts with anything in `frontend/CLAUDE.md` or root `CLAUDE.md`: THIS document wins for the scope of this fix. Outside the fix, the `CLAUDE.md` files remain authoritative.
+
+Ship it clean.

--- a/frontend/src/features/Obsidian/Obsidian.container.ts
+++ b/frontend/src/features/Obsidian/Obsidian.container.ts
@@ -5,7 +5,6 @@ import type {GlobalState} from "../../store";
 import {
     applyLayout,
     bulkExport,
-    selectLastApplyLayoutReport,
     selectLastBulkExportReport,
     selectLastSetupReport,
     selectObsidianError,
@@ -24,7 +23,6 @@ const mapStateToProps = (state: GlobalState): ObsidianStateProps => ({
     isApplyingLayout: selectObsidianIsApplyingLayout(state),
     isSetupInProgress: selectObsidianIsSetupInProgress(state),
     lastBulkExportReport: selectLastBulkExportReport(state),
-    lastApplyLayoutReport: selectLastApplyLayoutReport(state),
     lastSetupReport: selectLastSetupReport(state),
     error: selectObsidianError(state),
 });

--- a/frontend/src/features/Obsidian/Obsidian.container.ts
+++ b/frontend/src/features/Obsidian/Obsidian.container.ts
@@ -5,7 +5,6 @@ import type {GlobalState} from "../../store";
 import {
     applyLayout,
     bulkExport,
-    selectLastSetupReport,
     selectObsidianError,
     selectObsidianIsApplyingLayout,
     selectObsidianIsBulkExporting,
@@ -21,7 +20,6 @@ const mapStateToProps = (state: GlobalState): ObsidianStateProps => ({
     isBulkExporting: selectObsidianIsBulkExporting(state),
     isApplyingLayout: selectObsidianIsApplyingLayout(state),
     isSetupInProgress: selectObsidianIsSetupInProgress(state),
-    lastSetupReport: selectLastSetupReport(state),
     error: selectObsidianError(state),
 });
 

--- a/frontend/src/features/Obsidian/Obsidian.container.ts
+++ b/frontend/src/features/Obsidian/Obsidian.container.ts
@@ -5,7 +5,6 @@ import type {GlobalState} from "../../store";
 import {
     applyLayout,
     bulkExport,
-    selectLastBulkExportReport,
     selectLastSetupReport,
     selectObsidianError,
     selectObsidianIsApplyingLayout,
@@ -22,7 +21,6 @@ const mapStateToProps = (state: GlobalState): ObsidianStateProps => ({
     isBulkExporting: selectObsidianIsBulkExporting(state),
     isApplyingLayout: selectObsidianIsApplyingLayout(state),
     isSetupInProgress: selectObsidianIsSetupInProgress(state),
-    lastBulkExportReport: selectLastBulkExportReport(state),
     lastSetupReport: selectLastSetupReport(state),
     error: selectObsidianError(state),
 });

--- a/frontend/src/features/Obsidian/Obsidian.container.ts
+++ b/frontend/src/features/Obsidian/Obsidian.container.ts
@@ -5,7 +5,6 @@ import type {GlobalState} from "../../store";
 import {
     applyLayout,
     bulkExport,
-    selectObsidianError,
     selectObsidianIsApplyingLayout,
     selectObsidianIsBulkExporting,
     selectObsidianIsSetupInProgress,
@@ -20,7 +19,6 @@ const mapStateToProps = (state: GlobalState): ObsidianStateProps => ({
     isBulkExporting: selectObsidianIsBulkExporting(state),
     isApplyingLayout: selectObsidianIsApplyingLayout(state),
     isSetupInProgress: selectObsidianIsSetupInProgress(state),
-    error: selectObsidianError(state),
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): ObsidianDispatchProps =>

--- a/frontend/src/features/Obsidian/Obsidian.tsx
+++ b/frontend/src/features/Obsidian/Obsidian.tsx
@@ -32,7 +32,6 @@ const Obsidian: FC<ObsidianProps> = ({
                                          isBulkExporting,
                                          isApplyingLayout,
                                          isSetupInProgress,
-                                         lastSetupReport,
                                          error,
                                          onLoadSettings,
                                          onSaveSettings,
@@ -57,14 +56,6 @@ const Obsidian: FC<ObsidianProps> = ({
     useEffect(() => {
         if (error) toast.error(error);
     }, [error]);
-
-    useEffect(() => {
-        if (lastSetupReport) {
-            toast.success(
-                t("obsidian.setupSuccess", {created: lastSetupReport.createdPaths.length}),
-            );
-        }
-    }, [lastSetupReport, t]);
 
     const toggle = (key: string, required: boolean) => {
         if (required) return;

--- a/frontend/src/features/Obsidian/Obsidian.tsx
+++ b/frontend/src/features/Obsidian/Obsidian.tsx
@@ -33,7 +33,6 @@ const Obsidian: FC<ObsidianProps> = ({
                                          isApplyingLayout,
                                          isSetupInProgress,
                                          lastBulkExportReport,
-                                         lastApplyLayoutReport,
                                          lastSetupReport,
                                          error,
                                          onLoadSettings,
@@ -65,17 +64,6 @@ const Obsidian: FC<ObsidianProps> = ({
             toast.success(t("obsidian.syncAllSuccess", {count: lastBulkExportReport.exportedCount}));
         }
     }, [lastBulkExportReport, t]);
-
-    useEffect(() => {
-        if (lastApplyLayoutReport) {
-            toast.success(
-                t("obsidian.applyLayoutSuccess", {
-                    folders: lastApplyLayoutReport.createdFolders,
-                    notes: lastApplyLayoutReport.movedNotes,
-                }),
-            );
-        }
-    }, [lastApplyLayoutReport, t]);
 
     useEffect(() => {
         if (lastSetupReport) {

--- a/frontend/src/features/Obsidian/Obsidian.tsx
+++ b/frontend/src/features/Obsidian/Obsidian.tsx
@@ -32,7 +32,6 @@ const Obsidian: FC<ObsidianProps> = ({
                                          isBulkExporting,
                                          isApplyingLayout,
                                          isSetupInProgress,
-                                         error,
                                          onLoadSettings,
                                          onSaveSettings,
                                          onSetup,
@@ -52,10 +51,6 @@ const Obsidian: FC<ObsidianProps> = ({
     useEffect(() => {
         if (loadedSettings) setSettings(loadedSettings);
     }, [loadedSettings]);
-
-    useEffect(() => {
-        if (error) toast.error(error);
-    }, [error]);
 
     const toggle = (key: string, required: boolean) => {
         if (required) return;

--- a/frontend/src/features/Obsidian/Obsidian.tsx
+++ b/frontend/src/features/Obsidian/Obsidian.tsx
@@ -32,7 +32,6 @@ const Obsidian: FC<ObsidianProps> = ({
                                          isBulkExporting,
                                          isApplyingLayout,
                                          isSetupInProgress,
-                                         lastBulkExportReport,
                                          lastSetupReport,
                                          error,
                                          onLoadSettings,
@@ -58,12 +57,6 @@ const Obsidian: FC<ObsidianProps> = ({
     useEffect(() => {
         if (error) toast.error(error);
     }, [error]);
-
-    useEffect(() => {
-        if (lastBulkExportReport) {
-            toast.success(t("obsidian.syncAllSuccess", {count: lastBulkExportReport.exportedCount}));
-        }
-    }, [lastBulkExportReport, t]);
 
     useEffect(() => {
         if (lastSetupReport) {

--- a/frontend/src/features/Obsidian/__tests__/Obsidian.test.tsx
+++ b/frontend/src/features/Obsidian/__tests__/Obsidian.test.tsx
@@ -4,6 +4,7 @@ import {MemoryRouter} from "react-router-dom";
 import {ToastContainer} from "react-toastify";
 
 import Obsidian from "../index";
+import {watchNotificationsSagas} from "../../../store/slices/notifications";
 import {watchObsidianSagas} from "../../../store/slices/obsidian";
 import {watchSettingsSagas} from "../../../store/slices/settings";
 import type {MockApiBundle} from "../../../testUtils";
@@ -33,7 +34,7 @@ const renderObsidian = () =>
             <Obsidian/>
             <ToastContainer/>
         </MemoryRouter>,
-        {sagas: [watchObsidianSagas, watchSettingsSagas]},
+        {sagas: [watchNotificationsSagas, watchObsidianSagas, watchSettingsSagas]},
     );
 
 describe("Obsidian — first-class tab (BC-025 / Bug 22)", () => {

--- a/frontend/src/features/Obsidian/types.ts
+++ b/frontend/src/features/Obsidian/types.ts
@@ -1,6 +1,5 @@
 import type {AppSettings} from "../../domain/Settings";
 import type {
-    ObsidianApplyLayoutReport,
     ObsidianBulkExportReport,
     ObsidianSetupReport,
 } from "../../store/slices/obsidian/types";
@@ -11,7 +10,6 @@ export interface ObsidianStateProps {
     readonly isApplyingLayout: boolean;
     readonly isSetupInProgress: boolean;
     readonly lastBulkExportReport: ObsidianBulkExportReport | null;
-    readonly lastApplyLayoutReport: ObsidianApplyLayoutReport | null;
     readonly lastSetupReport: ObsidianSetupReport | null;
     readonly error: string | null;
 }

--- a/frontend/src/features/Obsidian/types.ts
+++ b/frontend/src/features/Obsidian/types.ts
@@ -1,15 +1,11 @@
 import type {AppSettings} from "../../domain/Settings";
-import type {
-    ObsidianBulkExportReport,
-    ObsidianSetupReport,
-} from "../../store/slices/obsidian/types";
+import type {ObsidianSetupReport} from "../../store/slices/obsidian/types";
 
 export interface ObsidianStateProps {
     readonly settings: AppSettings | null;
     readonly isBulkExporting: boolean;
     readonly isApplyingLayout: boolean;
     readonly isSetupInProgress: boolean;
-    readonly lastBulkExportReport: ObsidianBulkExportReport | null;
     readonly lastSetupReport: ObsidianSetupReport | null;
     readonly error: string | null;
 }

--- a/frontend/src/features/Obsidian/types.ts
+++ b/frontend/src/features/Obsidian/types.ts
@@ -1,12 +1,10 @@
 import type {AppSettings} from "../../domain/Settings";
-import type {ObsidianSetupReport} from "../../store/slices/obsidian/types";
 
 export interface ObsidianStateProps {
     readonly settings: AppSettings | null;
     readonly isBulkExporting: boolean;
     readonly isApplyingLayout: boolean;
     readonly isSetupInProgress: boolean;
-    readonly lastSetupReport: ObsidianSetupReport | null;
     readonly error: string | null;
 }
 

--- a/frontend/src/features/Obsidian/types.ts
+++ b/frontend/src/features/Obsidian/types.ts
@@ -5,7 +5,6 @@ export interface ObsidianStateProps {
     readonly isBulkExporting: boolean;
     readonly isApplyingLayout: boolean;
     readonly isSetupInProgress: boolean;
-    readonly error: string | null;
 }
 
 export interface ObsidianDispatchProps {

--- a/frontend/src/features/Settings/Settings.container.ts
+++ b/frontend/src/features/Settings/Settings.container.ts
@@ -8,7 +8,6 @@ import {
     saveSettings,
     selectLlmProbing,
     selectSettings,
-    selectSettingsError,
     selectSettingsLoading,
     selectSettingsSaving,
 } from "../../store/slices/settings";
@@ -20,7 +19,6 @@ const mapStateToProps = (state: GlobalState): SettingsStateProps => ({
     isLoading: selectSettingsLoading(state),
     isSaving: selectSettingsSaving(state),
     isLlmProbing: selectLlmProbing(state),
-    error: selectSettingsError(state),
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): SettingsDispatchProps =>

--- a/frontend/src/features/Settings/Settings.container.ts
+++ b/frontend/src/features/Settings/Settings.container.ts
@@ -6,7 +6,7 @@ import {
     checkLlm,
     loadSettings,
     saveSettings,
-    selectLlmProbe,
+    selectLlmProbing,
     selectSettings,
     selectSettingsError,
     selectSettingsLoading,
@@ -19,7 +19,7 @@ const mapStateToProps = (state: GlobalState): SettingsStateProps => ({
     settings: selectSettings(state),
     isLoading: selectSettingsLoading(state),
     isSaving: selectSettingsSaving(state),
-    llmProbe: selectLlmProbe(state),
+    isLlmProbing: selectLlmProbing(state),
     error: selectSettingsError(state),
 });
 

--- a/frontend/src/features/Settings/Settings.tsx
+++ b/frontend/src/features/Settings/Settings.tsx
@@ -20,7 +20,6 @@ const Settings: FC<SettingsProps> = ({
                                          settings: loadedSettings,
                                          isSaving,
                                          isLlmProbing,
-                                         error,
                                          onLoad,
                                          onSave,
                                          onCheckLlm,
@@ -42,10 +41,6 @@ const Settings: FC<SettingsProps> = ({
             setThemeMode(loadedSettings.themeMode);
         }
     }, [loadedSettings]);
-
-    useEffect(() => {
-        if (error) toast.error(error);
-    }, [error]);
 
     const update = <K extends keyof AppSettings>(key: K, value: AppSettings[K]) =>
         setDraft((prev) => ({...prev, [key]: value}));

--- a/frontend/src/features/Settings/Settings.tsx
+++ b/frontend/src/features/Settings/Settings.tsx
@@ -19,7 +19,7 @@ type TabKey = "general" | "storage" | "llm" | "whisper" | "dictation" | "obsidia
 const Settings: FC<SettingsProps> = ({
                                          settings: loadedSettings,
                                          isSaving,
-                                         llmProbe,
+                                         isLlmProbing,
                                          error,
                                          onLoad,
                                          onSave,
@@ -46,15 +46,6 @@ const Settings: FC<SettingsProps> = ({
     useEffect(() => {
         if (error) toast.error(error);
     }, [error]);
-
-    useEffect(() => {
-        if (llmProbe.ok === null || llmProbe.probing) return;
-        if (llmProbe.ok) {
-            toast.success("LLM: ✓");
-        } else {
-            toast.warning("LLM: ✗");
-        }
-    }, [llmProbe]);
 
     const update = <K extends keyof AppSettings>(key: K, value: AppSettings[K]) =>
         setDraft((prev) => ({...prev, [key]: value}));
@@ -171,7 +162,13 @@ const Settings: FC<SettingsProps> = ({
                             sensitive
                             hint={t("settings.tokenHint")}
                         />
-                        <Button variant="secondary" leftIcon={<Play size={16}/>} onClick={checkLlm}>
+                        <Button
+                            variant="secondary"
+                            leftIcon={<Play size={16}/>}
+                            onClick={checkLlm}
+                            isLoading={isLlmProbing}
+                            disabled={isLlmProbing}
+                        >
                             {t("settings.testConnection")}
                         </Button>
                     </FormGrid>

--- a/frontend/src/features/Settings/types.ts
+++ b/frontend/src/features/Settings/types.ts
@@ -4,7 +4,7 @@ export interface SettingsStateProps {
     readonly settings: AppSettings | null;
     readonly isLoading: boolean;
     readonly isSaving: boolean;
-    readonly llmProbe: { ok: boolean | null; probing: boolean };
+    readonly isLlmProbing: boolean;
     readonly error: string | null;
 }
 

--- a/frontend/src/features/Settings/types.ts
+++ b/frontend/src/features/Settings/types.ts
@@ -5,7 +5,6 @@ export interface SettingsStateProps {
     readonly isLoading: boolean;
     readonly isSaving: boolean;
     readonly isLlmProbing: boolean;
-    readonly error: string | null;
 }
 
 export interface SettingsDispatchProps {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -215,7 +215,9 @@
     },
     "testConnection": "Test connection",
     "tokenHint": "Stored locally in SQLite. Never leaves your machine except to the configured endpoint.",
-    "savedToast": "Settings saved"
+    "savedToast": "Settings saved",
+    "llmCheckSuccessToast": "LLM: connection OK",
+    "llmCheckFailureToast": "LLM: connection failed"
   },
   "sync": {
     "live": "Live",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -393,5 +393,8 @@
       "listening": "go ahead, I'm listening…",
       "finalizing": "wrapping up…"
     }
+  },
+  "errors": {
+    "genericErrorWithMessage": "Error: {{message}}"
   }
 }

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -393,5 +393,8 @@
       "listening": "говори, я слушаю…",
       "finalizing": "заканчиваю…"
     }
+  },
+  "errors": {
+    "genericErrorWithMessage": "Ошибка: {{message}}"
   }
 }

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -215,7 +215,9 @@
     },
     "testConnection": "Проверить соединение",
     "tokenHint": "Хранится локально в SQLite. Никогда не отправляется никуда, кроме указанного endpoint.",
-    "savedToast": "Настройки сохранены"
+    "savedToast": "Настройки сохранены",
+    "llmCheckSuccessToast": "LLM: соединение установлено",
+    "llmCheckFailureToast": "LLM: соединение не установлено"
   },
   "sync": {
     "live": "Онлайн",

--- a/frontend/src/store/rootSaga.ts
+++ b/frontend/src/store/rootSaga.ts
@@ -1,5 +1,6 @@
 import {all, fork, put} from "redux-saga/effects";
 import type {SagaIterator} from "redux-saga";
+import {watchNotificationsSagas} from "./slices/notifications";
 import {watchRecordingSagas} from "./slices/recording";
 import {watchSyncSagas} from "./slices/sync";
 import {watchRagSagas} from "./slices/rag";
@@ -15,6 +16,7 @@ function* bootstrapJobsSubscription(): SagaIterator {
 
 export function* rootSaga(): SagaIterator {
     yield all([
+        fork(watchNotificationsSagas),
         fork(watchRecordingSagas),
         fork(watchSyncSagas),
         fork(watchRagSagas),

--- a/frontend/src/store/slices/notifications/__tests__/saga.test.ts
+++ b/frontend/src/store/slices/notifications/__tests__/saga.test.ts
@@ -1,0 +1,80 @@
+import {expectSaga} from "redux-saga-test-plan";
+
+import {
+    notifyError,
+    notifyInfo,
+    notifySuccess,
+    notifyWarning,
+} from "../actions";
+import {watchNotificationsSagas} from "../saga";
+
+jest.mock("react-toastify", () => ({
+    toast: {
+        success: jest.fn(),
+        error: jest.fn(),
+        warning: jest.fn(),
+        info: jest.fn(),
+    },
+}));
+
+jest.mock("../../../../i18n", () => ({
+    __esModule: true,
+    default: {
+        t: jest.fn(
+            (key: string, params?: Record<string, unknown>) =>
+                `${key}::${JSON.stringify(params ?? {})}`,
+        ),
+    },
+}));
+
+const {toast} = jest.requireMock("react-toastify") as {
+    toast: {
+        success: jest.Mock;
+        error: jest.Mock;
+        warning: jest.Mock;
+        info: jest.Mock;
+    };
+};
+
+describe("notifications saga", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it("calls toast.success with translated message on NOTIFY_SUCCESS", async () => {
+        await expectSaga(watchNotificationsSagas)
+            .dispatch(notifySuccess({messageKey: "hello.world", params: {a: 1}}))
+            .silentRun(20);
+
+        expect(toast.success).toHaveBeenCalledTimes(1);
+        expect(toast.success).toHaveBeenCalledWith(`hello.world::${JSON.stringify({a: 1})}`);
+        expect(toast.error).not.toHaveBeenCalled();
+        expect(toast.warning).not.toHaveBeenCalled();
+        expect(toast.info).not.toHaveBeenCalled();
+    });
+
+    it("calls toast.error on NOTIFY_ERROR", async () => {
+        await expectSaga(watchNotificationsSagas)
+            .dispatch(notifyError({messageKey: "boom"}))
+            .silentRun(20);
+
+        expect(toast.error).toHaveBeenCalledTimes(1);
+        expect(toast.error).toHaveBeenCalledWith(`boom::${JSON.stringify({})}`);
+    });
+
+    it("calls toast.warning on NOTIFY_WARNING", async () => {
+        await expectSaga(watchNotificationsSagas)
+            .dispatch(notifyWarning({messageKey: "careful"}))
+            .silentRun(20);
+
+        expect(toast.warning).toHaveBeenCalledTimes(1);
+        expect(toast.warning).toHaveBeenCalledWith(`careful::${JSON.stringify({})}`);
+    });
+
+    it("calls toast.info on NOTIFY_INFO", async () => {
+        await expectSaga(watchNotificationsSagas)
+            .dispatch(notifyInfo({messageKey: "heads-up"}))
+            .silentRun(20);
+
+        expect(toast.info).toHaveBeenCalledTimes(1);
+        expect(toast.info).toHaveBeenCalledWith(`heads-up::${JSON.stringify({})}`);
+    });
+});

--- a/frontend/src/store/slices/notifications/actions.ts
+++ b/frontend/src/store/slices/notifications/actions.ts
@@ -1,0 +1,55 @@
+export const NOTIFY_SUCCESS = "notifications/NOTIFY_SUCCESS";
+export const NOTIFY_ERROR = "notifications/NOTIFY_ERROR";
+export const NOTIFY_WARNING = "notifications/NOTIFY_WARNING";
+export const NOTIFY_INFO = "notifications/NOTIFY_INFO";
+
+export interface NotifyPayload {
+    readonly messageKey: string;
+    readonly params?: Record<string, unknown>;
+}
+
+export interface NotifySuccessAction {
+    type: typeof NOTIFY_SUCCESS;
+    payload: NotifyPayload;
+}
+
+export interface NotifyErrorAction {
+    type: typeof NOTIFY_ERROR;
+    payload: NotifyPayload;
+}
+
+export interface NotifyWarningAction {
+    type: typeof NOTIFY_WARNING;
+    payload: NotifyPayload;
+}
+
+export interface NotifyInfoAction {
+    type: typeof NOTIFY_INFO;
+    payload: NotifyPayload;
+}
+
+export type NotificationAction =
+    | NotifySuccessAction
+    | NotifyErrorAction
+    | NotifyWarningAction
+    | NotifyInfoAction;
+
+export const notifySuccess = (payload: NotifyPayload): NotifySuccessAction => ({
+    type: NOTIFY_SUCCESS,
+    payload,
+});
+
+export const notifyError = (payload: NotifyPayload): NotifyErrorAction => ({
+    type: NOTIFY_ERROR,
+    payload,
+});
+
+export const notifyWarning = (payload: NotifyPayload): NotifyWarningAction => ({
+    type: NOTIFY_WARNING,
+    payload,
+});
+
+export const notifyInfo = (payload: NotifyPayload): NotifyInfoAction => ({
+    type: NOTIFY_INFO,
+    payload,
+});

--- a/frontend/src/store/slices/notifications/index.ts
+++ b/frontend/src/store/slices/notifications/index.ts
@@ -1,0 +1,2 @@
+export * from "./actions";
+export {watchNotificationsSagas} from "./saga";

--- a/frontend/src/store/slices/notifications/saga/index.ts
+++ b/frontend/src/store/slices/notifications/saga/index.ts
@@ -1,0 +1,1 @@
+export {showNotification, watchNotificationsSagas} from "./notificationsSaga";

--- a/frontend/src/store/slices/notifications/saga/notificationsSaga.ts
+++ b/frontend/src/store/slices/notifications/saga/notificationsSaga.ts
@@ -1,0 +1,42 @@
+import {call, takeEvery} from "redux-saga/effects";
+import type {SagaIterator} from "redux-saga";
+import {toast} from "react-toastify";
+
+import i18n from "../../../../i18n";
+import {
+    NOTIFY_ERROR,
+    NOTIFY_INFO,
+    NOTIFY_SUCCESS,
+    NOTIFY_WARNING,
+    type NotificationAction,
+} from "../actions";
+
+const translate = i18n.t.bind(i18n) as unknown as (
+    key: string,
+    params?: Record<string, unknown>,
+) => string;
+
+export function* showNotification(action: NotificationAction): SagaIterator {
+    const message = translate(action.payload.messageKey, action.payload.params);
+    switch (action.type) {
+        case NOTIFY_SUCCESS:
+            yield call([toast, toast.success], message);
+            return;
+        case NOTIFY_ERROR:
+            yield call([toast, toast.error], message);
+            return;
+        case NOTIFY_WARNING:
+            yield call([toast, toast.warning], message);
+            return;
+        case NOTIFY_INFO:
+            yield call([toast, toast.info], message);
+            return;
+    }
+}
+
+export function* watchNotificationsSagas(): SagaIterator {
+    yield takeEvery(
+        [NOTIFY_SUCCESS, NOTIFY_ERROR, NOTIFY_WARNING, NOTIFY_INFO],
+        showNotification,
+    );
+}

--- a/frontend/src/store/slices/obsidian/__tests__/applyLayoutSaga.test.ts
+++ b/frontend/src/store/slices/obsidian/__tests__/applyLayoutSaga.test.ts
@@ -1,0 +1,76 @@
+import {expectSaga} from "redux-saga-test-plan";
+import * as matchers from "redux-saga-test-plan/matchers";
+import {throwError} from "redux-saga-test-plan/providers";
+
+import {notifyError, notifySuccess} from "../../notifications";
+import {applyLayout, applyLayoutDone} from "../actions";
+import {obsidianReducer} from "../reducer";
+import {applyLayoutSaga} from "../saga/applyLayoutSaga";
+import type {ObsidianApplyLayoutReport} from "../types";
+
+jest.mock("../../../../api", () => {
+    const obsidianStub = {
+        applyLayout: jest.fn(),
+        bulkExport: jest.fn(),
+        setup: jest.fn(),
+    };
+    return {
+        apiFactory: {createObsidianApi: () => obsidianStub},
+        __obsidianStub: obsidianStub,
+    };
+});
+
+const obsidianStub = (
+    jest.requireMock("../../../../api") as {
+        __obsidianStub: { applyLayout: jest.Mock; bulkExport: jest.Mock; setup: jest.Mock };
+    }
+).__obsidianStub;
+
+const dispatch = (action: unknown) => action as Parameters<typeof obsidianReducer>[1];
+
+describe("applyLayoutSaga", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it("emits notifySuccess + APPLY_LAYOUT_DONE on happy path", async () => {
+        const report: ObsidianApplyLayoutReport = {createdFolders: 2, movedNotes: 5};
+        const result = await expectSaga(applyLayoutSaga)
+            .withReducer(obsidianReducer)
+            .provide([[matchers.call.fn(obsidianStub.applyLayout), report]])
+            .put(notifySuccess({
+                messageKey: "obsidian.applyLayoutSuccess",
+                params: {folders: 2, notes: 5},
+            }))
+            .put(applyLayoutDone())
+            .run();
+
+        expect(result.storeState.isApplyingLayout).toBe(false);
+        expect(result.storeState.error).toBeNull();
+    });
+
+    it("emits notifyError + APPLY_LAYOUT_DONE on throw", async () => {
+        const result = await expectSaga(applyLayoutSaga)
+            .withReducer(obsidianReducer)
+            .provide([[matchers.call.fn(obsidianStub.applyLayout), throwError(new Error("bad"))]])
+            .put(notifyError({
+                messageKey: "errors.genericErrorWithMessage",
+                params: {message: "bad"},
+            }))
+            .put(applyLayoutDone())
+            .run();
+
+        expect(result.storeState.isApplyingLayout).toBe(false);
+        expect(result.storeState.error).toBeNull();
+    });
+
+    it("reducer — APPLY_LAYOUT flips isApplyingLayout true", () => {
+        const state = obsidianReducer(undefined, dispatch(applyLayout()));
+        expect(state.isApplyingLayout).toBe(true);
+    });
+
+    it("reducer — APPLY_LAYOUT_DONE flips isApplyingLayout false and clears error", () => {
+        const progress = obsidianReducer(undefined, dispatch(applyLayout()));
+        const done = obsidianReducer(progress, dispatch(applyLayoutDone()));
+        expect(done.isApplyingLayout).toBe(false);
+        expect(done.error).toBeNull();
+    });
+});

--- a/frontend/src/store/slices/obsidian/__tests__/applyLayoutSaga.test.ts
+++ b/frontend/src/store/slices/obsidian/__tests__/applyLayoutSaga.test.ts
@@ -44,7 +44,6 @@ describe("applyLayoutSaga", () => {
             .run();
 
         expect(result.storeState.isApplyingLayout).toBe(false);
-        expect(result.storeState.error).toBeNull();
     });
 
     it("emits notifyError + APPLY_LAYOUT_DONE on throw", async () => {
@@ -59,7 +58,6 @@ describe("applyLayoutSaga", () => {
             .run();
 
         expect(result.storeState.isApplyingLayout).toBe(false);
-        expect(result.storeState.error).toBeNull();
     });
 
     it("reducer — APPLY_LAYOUT flips isApplyingLayout true", () => {
@@ -67,10 +65,9 @@ describe("applyLayoutSaga", () => {
         expect(state.isApplyingLayout).toBe(true);
     });
 
-    it("reducer — APPLY_LAYOUT_DONE flips isApplyingLayout false and clears error", () => {
+    it("reducer — APPLY_LAYOUT_DONE flips isApplyingLayout false", () => {
         const progress = obsidianReducer(undefined, dispatch(applyLayout()));
         const done = obsidianReducer(progress, dispatch(applyLayoutDone()));
         expect(done.isApplyingLayout).toBe(false);
-        expect(done.error).toBeNull();
     });
 });

--- a/frontend/src/store/slices/obsidian/__tests__/bulkExportSaga.test.ts
+++ b/frontend/src/store/slices/obsidian/__tests__/bulkExportSaga.test.ts
@@ -44,7 +44,6 @@ describe("bulkExportSaga", () => {
             .run();
 
         expect(result.storeState.isBulkExporting).toBe(false);
-        expect(result.storeState.error).toBeNull();
     });
 
     it("emits notifyError + BULK_EXPORT_DONE on throw", async () => {
@@ -59,7 +58,6 @@ describe("bulkExportSaga", () => {
             .run();
 
         expect(result.storeState.isBulkExporting).toBe(false);
-        expect(result.storeState.error).toBeNull();
     });
 
     it("reducer — BULK_EXPORT flips isBulkExporting true", () => {

--- a/frontend/src/store/slices/obsidian/__tests__/bulkExportSaga.test.ts
+++ b/frontend/src/store/slices/obsidian/__tests__/bulkExportSaga.test.ts
@@ -1,0 +1,75 @@
+import {expectSaga} from "redux-saga-test-plan";
+import * as matchers from "redux-saga-test-plan/matchers";
+import {throwError} from "redux-saga-test-plan/providers";
+
+import {notifyError, notifySuccess} from "../../notifications";
+import {bulkExport, bulkExportDone} from "../actions";
+import {obsidianReducer} from "../reducer";
+import {bulkExportSaga} from "../saga/bulkExportSaga";
+import type {ObsidianBulkExportReport} from "../types";
+
+jest.mock("../../../../api", () => {
+    const obsidianStub = {
+        applyLayout: jest.fn(),
+        bulkExport: jest.fn(),
+        setup: jest.fn(),
+    };
+    return {
+        apiFactory: {createObsidianApi: () => obsidianStub},
+        __obsidianStub: obsidianStub,
+    };
+});
+
+const obsidianStub = (
+    jest.requireMock("../../../../api") as {
+        __obsidianStub: { applyLayout: jest.Mock; bulkExport: jest.Mock; setup: jest.Mock };
+    }
+).__obsidianStub;
+
+const dispatch = (action: unknown) => action as Parameters<typeof obsidianReducer>[1];
+
+describe("bulkExportSaga", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it("emits notifySuccess + BULK_EXPORT_DONE on happy path", async () => {
+        const report: ObsidianBulkExportReport = {exportedCount: 42};
+        const result = await expectSaga(bulkExportSaga)
+            .withReducer(obsidianReducer)
+            .provide([[matchers.call.fn(obsidianStub.bulkExport), report]])
+            .put(notifySuccess({
+                messageKey: "obsidian.syncAllSuccess",
+                params: {count: 42},
+            }))
+            .put(bulkExportDone())
+            .run();
+
+        expect(result.storeState.isBulkExporting).toBe(false);
+        expect(result.storeState.error).toBeNull();
+    });
+
+    it("emits notifyError + BULK_EXPORT_DONE on throw", async () => {
+        const result = await expectSaga(bulkExportSaga)
+            .withReducer(obsidianReducer)
+            .provide([[matchers.call.fn(obsidianStub.bulkExport), throwError(new Error("oops"))]])
+            .put(notifyError({
+                messageKey: "errors.genericErrorWithMessage",
+                params: {message: "oops"},
+            }))
+            .put(bulkExportDone())
+            .run();
+
+        expect(result.storeState.isBulkExporting).toBe(false);
+        expect(result.storeState.error).toBeNull();
+    });
+
+    it("reducer — BULK_EXPORT flips isBulkExporting true", () => {
+        const state = obsidianReducer(undefined, dispatch(bulkExport()));
+        expect(state.isBulkExporting).toBe(true);
+    });
+
+    it("reducer — BULK_EXPORT_DONE flips isBulkExporting false", () => {
+        const progress = obsidianReducer(undefined, dispatch(bulkExport()));
+        const done = obsidianReducer(progress, dispatch(bulkExportDone()));
+        expect(done.isBulkExporting).toBe(false);
+    });
+});

--- a/frontend/src/store/slices/obsidian/__tests__/setupObsidianSaga.test.ts
+++ b/frontend/src/store/slices/obsidian/__tests__/setupObsidianSaga.test.ts
@@ -44,7 +44,6 @@ describe("setupObsidianSaga", () => {
             .run();
 
         expect(result.storeState.isSetupInProgress).toBe(false);
-        expect(result.storeState.error).toBeNull();
     });
 
     it("emits notifyError + SETUP_OBSIDIAN_DONE on throw", async () => {
@@ -59,7 +58,6 @@ describe("setupObsidianSaga", () => {
             .run();
 
         expect(result.storeState.isSetupInProgress).toBe(false);
-        expect(result.storeState.error).toBeNull();
     });
 
     it("reducer — SETUP_OBSIDIAN flips isSetupInProgress true", () => {

--- a/frontend/src/store/slices/obsidian/__tests__/setupObsidianSaga.test.ts
+++ b/frontend/src/store/slices/obsidian/__tests__/setupObsidianSaga.test.ts
@@ -1,0 +1,75 @@
+import {expectSaga} from "redux-saga-test-plan";
+import * as matchers from "redux-saga-test-plan/matchers";
+import {throwError} from "redux-saga-test-plan/providers";
+
+import {notifyError, notifySuccess} from "../../notifications";
+import {setupObsidian, setupObsidianDone} from "../actions";
+import {obsidianReducer} from "../reducer";
+import {setupObsidianSaga} from "../saga/setupObsidianSaga";
+import type {ObsidianSetupReport} from "../types";
+
+jest.mock("../../../../api", () => {
+    const obsidianStub = {
+        applyLayout: jest.fn(),
+        bulkExport: jest.fn(),
+        setup: jest.fn(),
+    };
+    return {
+        apiFactory: {createObsidianApi: () => obsidianStub},
+        __obsidianStub: obsidianStub,
+    };
+});
+
+const obsidianStub = (
+    jest.requireMock("../../../../api") as {
+        __obsidianStub: { applyLayout: jest.Mock; bulkExport: jest.Mock; setup: jest.Mock };
+    }
+).__obsidianStub;
+
+const dispatch = (action: unknown) => action as Parameters<typeof obsidianReducer>[1];
+
+describe("setupObsidianSaga", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it("emits notifySuccess + SETUP_OBSIDIAN_DONE on happy path", async () => {
+        const report: ObsidianSetupReport = {createdPaths: ["/a", "/b", "/c"]};
+        const result = await expectSaga(setupObsidianSaga, setupObsidian("/tmp/vault"))
+            .withReducer(obsidianReducer)
+            .provide([[matchers.call.fn(obsidianStub.setup), report]])
+            .put(notifySuccess({
+                messageKey: "obsidian.setupSuccess",
+                params: {created: 3},
+            }))
+            .put(setupObsidianDone())
+            .run();
+
+        expect(result.storeState.isSetupInProgress).toBe(false);
+        expect(result.storeState.error).toBeNull();
+    });
+
+    it("emits notifyError + SETUP_OBSIDIAN_DONE on throw", async () => {
+        const result = await expectSaga(setupObsidianSaga, setupObsidian("/tmp/vault"))
+            .withReducer(obsidianReducer)
+            .provide([[matchers.call.fn(obsidianStub.setup), throwError(new Error("nope"))]])
+            .put(notifyError({
+                messageKey: "errors.genericErrorWithMessage",
+                params: {message: "nope"},
+            }))
+            .put(setupObsidianDone())
+            .run();
+
+        expect(result.storeState.isSetupInProgress).toBe(false);
+        expect(result.storeState.error).toBeNull();
+    });
+
+    it("reducer — SETUP_OBSIDIAN flips isSetupInProgress true", () => {
+        const state = obsidianReducer(undefined, dispatch(setupObsidian("/v")));
+        expect(state.isSetupInProgress).toBe(true);
+    });
+
+    it("reducer — SETUP_OBSIDIAN_DONE flips isSetupInProgress false", () => {
+        const progress = obsidianReducer(undefined, dispatch(setupObsidian("/v")));
+        const done = obsidianReducer(progress, dispatch(setupObsidianDone()));
+        expect(done.isSetupInProgress).toBe(false);
+    });
+});

--- a/frontend/src/store/slices/obsidian/actions.ts
+++ b/frontend/src/store/slices/obsidian/actions.ts
@@ -1,8 +1,5 @@
-import type {ObsidianSetupReport} from "./types";
-
 export const SETUP_OBSIDIAN = "obsidian/SETUP";
-export const SETUP_OBSIDIAN_SUCCESS = "obsidian/SETUP_SUCCESS";
-export const SETUP_OBSIDIAN_FAILURE = "obsidian/SETUP_FAILURE";
+export const SETUP_OBSIDIAN_DONE = "obsidian/SETUP_DONE";
 
 export const BULK_EXPORT = "obsidian/BULK_EXPORT";
 export const BULK_EXPORT_DONE = "obsidian/BULK_EXPORT_DONE";
@@ -15,14 +12,8 @@ export interface SetupObsidianAction {
     payload: { vaultPath?: string };
 }
 
-export interface SetupObsidianSuccessAction {
-    type: typeof SETUP_OBSIDIAN_SUCCESS;
-    payload: ObsidianSetupReport;
-}
-
-export interface SetupObsidianFailureAction {
-    type: typeof SETUP_OBSIDIAN_FAILURE;
-    payload: string;
+export interface SetupObsidianDoneAction {
+    type: typeof SETUP_OBSIDIAN_DONE;
 }
 
 export interface BulkExportAction {
@@ -43,8 +34,7 @@ export interface ApplyLayoutDoneAction {
 
 export type ObsidianAction =
     | SetupObsidianAction
-    | SetupObsidianSuccessAction
-    | SetupObsidianFailureAction
+    | SetupObsidianDoneAction
     | BulkExportAction
     | BulkExportDoneAction
     | ApplyLayoutAction
@@ -54,13 +44,7 @@ export const setupObsidian = (vaultPath?: string): SetupObsidianAction => ({
     type: SETUP_OBSIDIAN,
     payload: {vaultPath},
 });
-export const setupObsidianSuccess = (
-    report: ObsidianSetupReport,
-): SetupObsidianSuccessAction => ({type: SETUP_OBSIDIAN_SUCCESS, payload: report});
-export const setupObsidianFailure = (message: string): SetupObsidianFailureAction => ({
-    type: SETUP_OBSIDIAN_FAILURE,
-    payload: message,
-});
+export const setupObsidianDone = (): SetupObsidianDoneAction => ({type: SETUP_OBSIDIAN_DONE});
 
 export const bulkExport = (): BulkExportAction => ({type: BULK_EXPORT});
 export const bulkExportDone = (): BulkExportDoneAction => ({type: BULK_EXPORT_DONE});

--- a/frontend/src/store/slices/obsidian/actions.ts
+++ b/frontend/src/store/slices/obsidian/actions.ts
@@ -1,4 +1,4 @@
-import type {ObsidianApplyLayoutReport, ObsidianBulkExportReport, ObsidianSetupReport,} from "./types";
+import type {ObsidianBulkExportReport, ObsidianSetupReport} from "./types";
 
 export const SETUP_OBSIDIAN = "obsidian/SETUP";
 export const SETUP_OBSIDIAN_SUCCESS = "obsidian/SETUP_SUCCESS";
@@ -9,8 +9,7 @@ export const BULK_EXPORT_SUCCESS = "obsidian/BULK_EXPORT_SUCCESS";
 export const BULK_EXPORT_FAILURE = "obsidian/BULK_EXPORT_FAILURE";
 
 export const APPLY_LAYOUT = "obsidian/APPLY_LAYOUT";
-export const APPLY_LAYOUT_SUCCESS = "obsidian/APPLY_LAYOUT_SUCCESS";
-export const APPLY_LAYOUT_FAILURE = "obsidian/APPLY_LAYOUT_FAILURE";
+export const APPLY_LAYOUT_DONE = "obsidian/APPLY_LAYOUT_DONE";
 
 export interface SetupObsidianAction {
     type: typeof SETUP_OBSIDIAN;
@@ -45,14 +44,8 @@ export interface ApplyLayoutAction {
     type: typeof APPLY_LAYOUT;
 }
 
-export interface ApplyLayoutSuccessAction {
-    type: typeof APPLY_LAYOUT_SUCCESS;
-    payload: ObsidianApplyLayoutReport;
-}
-
-export interface ApplyLayoutFailureAction {
-    type: typeof APPLY_LAYOUT_FAILURE;
-    payload: string;
+export interface ApplyLayoutDoneAction {
+    type: typeof APPLY_LAYOUT_DONE;
 }
 
 export type ObsidianAction =
@@ -63,8 +56,7 @@ export type ObsidianAction =
     | BulkExportSuccessAction
     | BulkExportFailureAction
     | ApplyLayoutAction
-    | ApplyLayoutSuccessAction
-    | ApplyLayoutFailureAction;
+    | ApplyLayoutDoneAction;
 
 export const setupObsidian = (vaultPath?: string): SetupObsidianAction => ({
     type: SETUP_OBSIDIAN,
@@ -88,10 +80,4 @@ export const bulkExportFailure = (message: string): BulkExportFailureAction => (
 });
 
 export const applyLayout = (): ApplyLayoutAction => ({type: APPLY_LAYOUT});
-export const applyLayoutSuccess = (
-    report: ObsidianApplyLayoutReport,
-): ApplyLayoutSuccessAction => ({type: APPLY_LAYOUT_SUCCESS, payload: report});
-export const applyLayoutFailure = (message: string): ApplyLayoutFailureAction => ({
-    type: APPLY_LAYOUT_FAILURE,
-    payload: message,
-});
+export const applyLayoutDone = (): ApplyLayoutDoneAction => ({type: APPLY_LAYOUT_DONE});

--- a/frontend/src/store/slices/obsidian/actions.ts
+++ b/frontend/src/store/slices/obsidian/actions.ts
@@ -1,12 +1,11 @@
-import type {ObsidianBulkExportReport, ObsidianSetupReport} from "./types";
+import type {ObsidianSetupReport} from "./types";
 
 export const SETUP_OBSIDIAN = "obsidian/SETUP";
 export const SETUP_OBSIDIAN_SUCCESS = "obsidian/SETUP_SUCCESS";
 export const SETUP_OBSIDIAN_FAILURE = "obsidian/SETUP_FAILURE";
 
 export const BULK_EXPORT = "obsidian/BULK_EXPORT";
-export const BULK_EXPORT_SUCCESS = "obsidian/BULK_EXPORT_SUCCESS";
-export const BULK_EXPORT_FAILURE = "obsidian/BULK_EXPORT_FAILURE";
+export const BULK_EXPORT_DONE = "obsidian/BULK_EXPORT_DONE";
 
 export const APPLY_LAYOUT = "obsidian/APPLY_LAYOUT";
 export const APPLY_LAYOUT_DONE = "obsidian/APPLY_LAYOUT_DONE";
@@ -30,14 +29,8 @@ export interface BulkExportAction {
     type: typeof BULK_EXPORT;
 }
 
-export interface BulkExportSuccessAction {
-    type: typeof BULK_EXPORT_SUCCESS;
-    payload: ObsidianBulkExportReport;
-}
-
-export interface BulkExportFailureAction {
-    type: typeof BULK_EXPORT_FAILURE;
-    payload: string;
+export interface BulkExportDoneAction {
+    type: typeof BULK_EXPORT_DONE;
 }
 
 export interface ApplyLayoutAction {
@@ -53,8 +46,7 @@ export type ObsidianAction =
     | SetupObsidianSuccessAction
     | SetupObsidianFailureAction
     | BulkExportAction
-    | BulkExportSuccessAction
-    | BulkExportFailureAction
+    | BulkExportDoneAction
     | ApplyLayoutAction
     | ApplyLayoutDoneAction;
 
@@ -71,13 +63,7 @@ export const setupObsidianFailure = (message: string): SetupObsidianFailureActio
 });
 
 export const bulkExport = (): BulkExportAction => ({type: BULK_EXPORT});
-export const bulkExportSuccess = (
-    report: ObsidianBulkExportReport,
-): BulkExportSuccessAction => ({type: BULK_EXPORT_SUCCESS, payload: report});
-export const bulkExportFailure = (message: string): BulkExportFailureAction => ({
-    type: BULK_EXPORT_FAILURE,
-    payload: message,
-});
+export const bulkExportDone = (): BulkExportDoneAction => ({type: BULK_EXPORT_DONE});
 
 export const applyLayout = (): ApplyLayoutAction => ({type: APPLY_LAYOUT});
 export const applyLayoutDone = (): ApplyLayoutDoneAction => ({type: APPLY_LAYOUT_DONE});

--- a/frontend/src/store/slices/obsidian/mutations.ts
+++ b/frontend/src/store/slices/obsidian/mutations.ts
@@ -3,17 +3,14 @@ import type {ObsidianState} from "./types";
 export const beginSetup = (state: ObsidianState): ObsidianState => ({
     ...state,
     isSetupInProgress: true,
-    error: null,
 });
 
 export const beginBulkExport = (state: ObsidianState): ObsidianState => ({
     ...state,
     isBulkExporting: true,
-    error: null,
 });
 
 export const beginApplyLayout = (state: ObsidianState): ObsidianState => ({
     ...state,
     isApplyingLayout: true,
-    error: null,
 });

--- a/frontend/src/store/slices/obsidian/reducer.ts
+++ b/frontend/src/store/slices/obsidian/reducer.ts
@@ -4,8 +4,7 @@ import {
     APPLY_LAYOUT,
     APPLY_LAYOUT_DONE,
     BULK_EXPORT,
-    BULK_EXPORT_FAILURE,
-    BULK_EXPORT_SUCCESS,
+    BULK_EXPORT_DONE,
     type ObsidianAction,
     SETUP_OBSIDIAN,
     SETUP_OBSIDIAN_FAILURE,
@@ -34,15 +33,8 @@ export const obsidianReducer: Reducer<ObsidianState> = (
 
         case BULK_EXPORT:
             return beginBulkExport(state);
-        case BULK_EXPORT_SUCCESS:
-            return {
-                ...state,
-                isBulkExporting: false,
-                lastBulkExportReport: typed.payload,
-                error: null,
-            };
-        case BULK_EXPORT_FAILURE:
-            return {...state, isBulkExporting: false, error: typed.payload};
+        case BULK_EXPORT_DONE:
+            return {...state, isBulkExporting: false, error: null};
 
         case APPLY_LAYOUT:
             return beginApplyLayout(state);

--- a/frontend/src/store/slices/obsidian/reducer.ts
+++ b/frontend/src/store/slices/obsidian/reducer.ts
@@ -7,8 +7,7 @@ import {
     BULK_EXPORT_DONE,
     type ObsidianAction,
     SETUP_OBSIDIAN,
-    SETUP_OBSIDIAN_FAILURE,
-    SETUP_OBSIDIAN_SUCCESS,
+    SETUP_OBSIDIAN_DONE,
 } from "./actions";
 import {beginApplyLayout, beginBulkExport, beginSetup} from "./mutations";
 import {initialObsidianState, type ObsidianState} from "./types";
@@ -21,15 +20,8 @@ export const obsidianReducer: Reducer<ObsidianState> = (
     switch (typed.type) {
         case SETUP_OBSIDIAN:
             return beginSetup(state);
-        case SETUP_OBSIDIAN_SUCCESS:
-            return {
-                ...state,
-                isSetupInProgress: false,
-                lastSetupReport: typed.payload,
-                error: null,
-            };
-        case SETUP_OBSIDIAN_FAILURE:
-            return {...state, isSetupInProgress: false, error: typed.payload};
+        case SETUP_OBSIDIAN_DONE:
+            return {...state, isSetupInProgress: false, error: null};
 
         case BULK_EXPORT:
             return beginBulkExport(state);

--- a/frontend/src/store/slices/obsidian/reducer.ts
+++ b/frontend/src/store/slices/obsidian/reducer.ts
@@ -21,17 +21,17 @@ export const obsidianReducer: Reducer<ObsidianState> = (
         case SETUP_OBSIDIAN:
             return beginSetup(state);
         case SETUP_OBSIDIAN_DONE:
-            return {...state, isSetupInProgress: false, error: null};
+            return {...state, isSetupInProgress: false};
 
         case BULK_EXPORT:
             return beginBulkExport(state);
         case BULK_EXPORT_DONE:
-            return {...state, isBulkExporting: false, error: null};
+            return {...state, isBulkExporting: false};
 
         case APPLY_LAYOUT:
             return beginApplyLayout(state);
         case APPLY_LAYOUT_DONE:
-            return {...state, isApplyingLayout: false, error: null};
+            return {...state, isApplyingLayout: false};
 
         default:
             return state;

--- a/frontend/src/store/slices/obsidian/reducer.ts
+++ b/frontend/src/store/slices/obsidian/reducer.ts
@@ -2,8 +2,7 @@ import type {Reducer} from "redux";
 
 import {
     APPLY_LAYOUT,
-    APPLY_LAYOUT_FAILURE,
-    APPLY_LAYOUT_SUCCESS,
+    APPLY_LAYOUT_DONE,
     BULK_EXPORT,
     BULK_EXPORT_FAILURE,
     BULK_EXPORT_SUCCESS,
@@ -47,15 +46,8 @@ export const obsidianReducer: Reducer<ObsidianState> = (
 
         case APPLY_LAYOUT:
             return beginApplyLayout(state);
-        case APPLY_LAYOUT_SUCCESS:
-            return {
-                ...state,
-                isApplyingLayout: false,
-                lastApplyLayoutReport: typed.payload,
-                error: null,
-            };
-        case APPLY_LAYOUT_FAILURE:
-            return {...state, isApplyingLayout: false, error: typed.payload};
+        case APPLY_LAYOUT_DONE:
+            return {...state, isApplyingLayout: false, error: null};
 
         default:
             return state;

--- a/frontend/src/store/slices/obsidian/saga/applyLayoutSaga.ts
+++ b/frontend/src/store/slices/obsidian/saga/applyLayoutSaga.ts
@@ -2,7 +2,8 @@ import {call, put, takeLatest} from "redux-saga/effects";
 import type {SagaIterator} from "redux-saga";
 
 import {apiFactory} from "../../../../api";
-import {APPLY_LAYOUT, applyLayoutFailure, applyLayoutSuccess} from "../actions";
+import {notifyError, notifySuccess} from "../../notifications";
+import {APPLY_LAYOUT, applyLayoutDone} from "../actions";
 import type {ObsidianApplyLayoutReport} from "../types";
 
 export function* applyLayoutSaga(): SagaIterator {
@@ -12,11 +13,18 @@ export function* applyLayoutSaga(): SagaIterator {
             obsidianApi,
             obsidianApi.applyLayout,
         ]);
-        yield put(applyLayoutSuccess(report));
+        yield put(notifySuccess({
+            messageKey: "obsidian.applyLayoutSuccess",
+            params: {folders: report.createdFolders, notes: report.movedNotes},
+        }));
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        yield put(applyLayoutFailure(message));
+        yield put(notifyError({
+            messageKey: "errors.genericErrorWithMessage",
+            params: {message},
+        }));
     }
+    yield put(applyLayoutDone());
 }
 
 export function* watchApplyLayout(): SagaIterator {

--- a/frontend/src/store/slices/obsidian/saga/bulkExportSaga.ts
+++ b/frontend/src/store/slices/obsidian/saga/bulkExportSaga.ts
@@ -2,7 +2,8 @@ import {call, put, takeLatest} from "redux-saga/effects";
 import type {SagaIterator} from "redux-saga";
 
 import {apiFactory} from "../../../../api";
-import {BULK_EXPORT, bulkExportFailure, bulkExportSuccess} from "../actions";
+import {notifyError, notifySuccess} from "../../notifications";
+import {BULK_EXPORT, bulkExportDone} from "../actions";
 import type {ObsidianBulkExportReport} from "../types";
 
 export function* bulkExportSaga(): SagaIterator {
@@ -12,11 +13,18 @@ export function* bulkExportSaga(): SagaIterator {
             obsidianApi,
             obsidianApi.bulkExport,
         ]);
-        yield put(bulkExportSuccess(report));
+        yield put(notifySuccess({
+            messageKey: "obsidian.syncAllSuccess",
+            params: {count: report.exportedCount},
+        }));
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        yield put(bulkExportFailure(message));
+        yield put(notifyError({
+            messageKey: "errors.genericErrorWithMessage",
+            params: {message},
+        }));
     }
+    yield put(bulkExportDone());
 }
 
 export function* watchBulkExport(): SagaIterator {

--- a/frontend/src/store/slices/obsidian/saga/setupObsidianSaga.ts
+++ b/frontend/src/store/slices/obsidian/saga/setupObsidianSaga.ts
@@ -2,7 +2,8 @@ import {call, put, takeLatest} from "redux-saga/effects";
 import type {SagaIterator} from "redux-saga";
 
 import {apiFactory} from "../../../../api";
-import {SETUP_OBSIDIAN, type SetupObsidianAction, setupObsidianFailure, setupObsidianSuccess,} from "../actions";
+import {notifyError, notifySuccess} from "../../notifications";
+import {SETUP_OBSIDIAN, type SetupObsidianAction, setupObsidianDone,} from "../actions";
 import type {ObsidianSetupReport} from "../types";
 
 export function* setupObsidianSaga(action: SetupObsidianAction): SagaIterator {
@@ -12,11 +13,18 @@ export function* setupObsidianSaga(action: SetupObsidianAction): SagaIterator {
             [obsidianApi, obsidianApi.setup],
             action.payload.vaultPath,
         );
-        yield put(setupObsidianSuccess(report));
+        yield put(notifySuccess({
+            messageKey: "obsidian.setupSuccess",
+            params: {created: report.createdPaths.length},
+        }));
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        yield put(setupObsidianFailure(message));
+        yield put(notifyError({
+            messageKey: "errors.genericErrorWithMessage",
+            params: {message},
+        }));
     }
+    yield put(setupObsidianDone());
 }
 
 export function* watchSetupObsidian(): SagaIterator {

--- a/frontend/src/store/slices/obsidian/selectors.ts
+++ b/frontend/src/store/slices/obsidian/selectors.ts
@@ -16,7 +16,3 @@ export const selectObsidianIsSetupInProgress = createSelector(
     selectObsidianState,
     (slice) => slice.isSetupInProgress,
 );
-export const selectObsidianError = createSelector(
-    selectObsidianState,
-    (slice) => slice.error,
-);

--- a/frontend/src/store/slices/obsidian/selectors.ts
+++ b/frontend/src/store/slices/obsidian/selectors.ts
@@ -24,10 +24,6 @@ export const selectLastBulkExportReport = createSelector(
     selectObsidianState,
     (slice) => slice.lastBulkExportReport,
 );
-export const selectLastApplyLayoutReport = createSelector(
-    selectObsidianState,
-    (slice) => slice.lastApplyLayoutReport,
-);
 export const selectLastSetupReport = createSelector(
     selectObsidianState,
     (slice) => slice.lastSetupReport,

--- a/frontend/src/store/slices/obsidian/selectors.ts
+++ b/frontend/src/store/slices/obsidian/selectors.ts
@@ -20,10 +20,6 @@ export const selectObsidianError = createSelector(
     selectObsidianState,
     (slice) => slice.error,
 );
-export const selectLastBulkExportReport = createSelector(
-    selectObsidianState,
-    (slice) => slice.lastBulkExportReport,
-);
 export const selectLastSetupReport = createSelector(
     selectObsidianState,
     (slice) => slice.lastSetupReport,

--- a/frontend/src/store/slices/obsidian/selectors.ts
+++ b/frontend/src/store/slices/obsidian/selectors.ts
@@ -20,7 +20,3 @@ export const selectObsidianError = createSelector(
     selectObsidianState,
     (slice) => slice.error,
 );
-export const selectLastSetupReport = createSelector(
-    selectObsidianState,
-    (slice) => slice.lastSetupReport,
-);

--- a/frontend/src/store/slices/obsidian/types.ts
+++ b/frontend/src/store/slices/obsidian/types.ts
@@ -15,7 +15,6 @@ export interface ObsidianState {
     readonly isSetupInProgress: boolean;
     readonly isBulkExporting: boolean;
     readonly isApplyingLayout: boolean;
-    readonly lastSetupReport: ObsidianSetupReport | null;
     readonly error: string | null;
 }
 
@@ -23,6 +22,5 @@ export const initialObsidianState: ObsidianState = {
     isSetupInProgress: false,
     isBulkExporting: false,
     isApplyingLayout: false,
-    lastSetupReport: null,
     error: null,
 };

--- a/frontend/src/store/slices/obsidian/types.ts
+++ b/frontend/src/store/slices/obsidian/types.ts
@@ -16,7 +16,6 @@ export interface ObsidianState {
     readonly isBulkExporting: boolean;
     readonly isApplyingLayout: boolean;
     readonly lastSetupReport: ObsidianSetupReport | null;
-    readonly lastBulkExportReport: ObsidianBulkExportReport | null;
     readonly error: string | null;
 }
 
@@ -25,6 +24,5 @@ export const initialObsidianState: ObsidianState = {
     isBulkExporting: false,
     isApplyingLayout: false,
     lastSetupReport: null,
-    lastBulkExportReport: null,
     error: null,
 };

--- a/frontend/src/store/slices/obsidian/types.ts
+++ b/frontend/src/store/slices/obsidian/types.ts
@@ -17,7 +17,6 @@ export interface ObsidianState {
     readonly isApplyingLayout: boolean;
     readonly lastSetupReport: ObsidianSetupReport | null;
     readonly lastBulkExportReport: ObsidianBulkExportReport | null;
-    readonly lastApplyLayoutReport: ObsidianApplyLayoutReport | null;
     readonly error: string | null;
 }
 
@@ -27,6 +26,5 @@ export const initialObsidianState: ObsidianState = {
     isApplyingLayout: false,
     lastSetupReport: null,
     lastBulkExportReport: null,
-    lastApplyLayoutReport: null,
     error: null,
 };

--- a/frontend/src/store/slices/obsidian/types.ts
+++ b/frontend/src/store/slices/obsidian/types.ts
@@ -15,12 +15,10 @@ export interface ObsidianState {
     readonly isSetupInProgress: boolean;
     readonly isBulkExporting: boolean;
     readonly isApplyingLayout: boolean;
-    readonly error: string | null;
 }
 
 export const initialObsidianState: ObsidianState = {
     isSetupInProgress: false,
     isBulkExporting: false,
     isApplyingLayout: false,
-    error: null,
 };

--- a/frontend/src/store/slices/settings/__tests__/checkLlmSaga.test.ts
+++ b/frontend/src/store/slices/settings/__tests__/checkLlmSaga.test.ts
@@ -1,0 +1,70 @@
+import {expectSaga} from "redux-saga-test-plan";
+import * as matchers from "redux-saga-test-plan/matchers";
+import {throwError} from "redux-saga-test-plan/providers";
+
+import {notifySuccess, notifyWarning} from "../../notifications";
+import {checkLlm, checkLlmDone} from "../actions";
+import {checkLlmSaga} from "../saga/checkLlmSaga";
+import {settingsReducer} from "../reducer";
+
+jest.mock("../../../../api", () => {
+    const healthStub = {checkLlm: jest.fn()};
+    return {
+        apiFactory: {createHealthApi: () => healthStub},
+        __healthStub: healthStub,
+    };
+});
+
+const healthStub = (
+    jest.requireMock("../../../../api") as { __healthStub: { checkLlm: jest.Mock } }
+).__healthStub;
+
+const dispatch = (action: unknown) => action as Parameters<typeof settingsReducer>[1];
+
+describe("checkLlmSaga", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it("emits notifySuccess + CHECK_LLM_DONE on ok=true", async () => {
+        const result = await expectSaga(checkLlmSaga)
+            .withReducer(settingsReducer)
+            .provide([[matchers.call.fn(healthStub.checkLlm), true]])
+            .put(notifySuccess({messageKey: "settings.llmCheckSuccessToast"}))
+            .put(checkLlmDone())
+            .run();
+
+        expect(result.storeState.llmProbe.probing).toBe(false);
+    });
+
+    it("emits notifyWarning + CHECK_LLM_DONE on ok=false", async () => {
+        const result = await expectSaga(checkLlmSaga)
+            .withReducer(settingsReducer)
+            .provide([[matchers.call.fn(healthStub.checkLlm), false]])
+            .put(notifyWarning({messageKey: "settings.llmCheckFailureToast"}))
+            .put(checkLlmDone())
+            .run();
+
+        expect(result.storeState.llmProbe.probing).toBe(false);
+    });
+
+    it("emits notifyWarning + CHECK_LLM_DONE when API throws", async () => {
+        const result = await expectSaga(checkLlmSaga)
+            .withReducer(settingsReducer)
+            .provide([[matchers.call.fn(healthStub.checkLlm), throwError(new Error("down"))]])
+            .put(notifyWarning({messageKey: "settings.llmCheckFailureToast"}))
+            .put(checkLlmDone())
+            .run();
+
+        expect(result.storeState.llmProbe.probing).toBe(false);
+    });
+
+    it("reducer — CHECK_LLM flips probing to true", () => {
+        const state = settingsReducer(undefined, dispatch(checkLlm()));
+        expect(state.llmProbe.probing).toBe(true);
+    });
+
+    it("reducer — CHECK_LLM_DONE flips probing to false", () => {
+        const probing = settingsReducer(undefined, dispatch(checkLlm()));
+        const done = settingsReducer(probing, dispatch(checkLlmDone()));
+        expect(done.llmProbe.probing).toBe(false);
+    });
+});

--- a/frontend/src/store/slices/settings/__tests__/loadSettingsSaga.test.ts
+++ b/frontend/src/store/slices/settings/__tests__/loadSettingsSaga.test.ts
@@ -1,0 +1,53 @@
+import {expectSaga} from "redux-saga-test-plan";
+import * as matchers from "redux-saga-test-plan/matchers";
+import {throwError} from "redux-saga-test-plan/providers";
+
+import type {AppSettings} from "../../../../domain/Settings";
+import {notifyError} from "../../notifications";
+import {loadSettingsFailure, loadSettingsSuccess} from "../actions";
+import {loadSettingsSaga} from "../saga/loadSettingsSaga";
+import {settingsReducer} from "../reducer";
+
+jest.mock("../../../../api", () => {
+    const settingsStub = {getSettings: jest.fn(), saveSettings: jest.fn()};
+    return {
+        apiFactory: {createSettingsApi: () => settingsStub},
+        __settingsStub: settingsStub,
+    };
+});
+
+const settingsStub = (
+    jest.requireMock("../../../../api") as {
+        __settingsStub: { getSettings: jest.Mock; saveSettings: jest.Mock };
+    }
+).__settingsStub;
+
+const fakeSettings = {language: "ru", themeMode: "system"} as unknown as AppSettings;
+
+describe("loadSettingsSaga", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it("puts loadSettingsSuccess on happy path", async () => {
+        await expectSaga(loadSettingsSaga)
+            .withReducer(settingsReducer)
+            .provide([[matchers.call.fn(settingsStub.getSettings), fakeSettings]])
+            .put(loadSettingsSuccess(fakeSettings))
+            .run();
+    });
+
+    it("puts notifyError + loadSettingsFailure on throw", async () => {
+        const result = await expectSaga(loadSettingsSaga)
+            .withReducer(settingsReducer)
+            .provide([
+                [matchers.call.fn(settingsStub.getSettings), throwError(new Error("no net"))],
+            ])
+            .put(notifyError({
+                messageKey: "errors.genericErrorWithMessage",
+                params: {message: "no net"},
+            }))
+            .put(loadSettingsFailure())
+            .run();
+
+        expect(result.storeState.isLoading).toBe(false);
+    });
+});

--- a/frontend/src/store/slices/settings/__tests__/saveSettingsSaga.test.ts
+++ b/frontend/src/store/slices/settings/__tests__/saveSettingsSaga.test.ts
@@ -1,0 +1,53 @@
+import {expectSaga} from "redux-saga-test-plan";
+import * as matchers from "redux-saga-test-plan/matchers";
+import {throwError} from "redux-saga-test-plan/providers";
+
+import type {AppSettings} from "../../../../domain/Settings";
+import {notifyError} from "../../notifications";
+import {saveSettings, saveSettingsFailure, saveSettingsSuccess} from "../actions";
+import {saveSettingsSaga} from "../saga/saveSettingsSaga";
+import {settingsReducer} from "../reducer";
+
+jest.mock("../../../../api", () => {
+    const settingsStub = {getSettings: jest.fn(), saveSettings: jest.fn()};
+    return {
+        apiFactory: {createSettingsApi: () => settingsStub},
+        __settingsStub: settingsStub,
+    };
+});
+
+const settingsStub = (
+    jest.requireMock("../../../../api") as {
+        __settingsStub: { getSettings: jest.Mock; saveSettings: jest.Mock };
+    }
+).__settingsStub;
+
+const fakeSettings = {language: "ru", themeMode: "light"} as unknown as AppSettings;
+
+describe("saveSettingsSaga", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it("puts saveSettingsSuccess on happy path", async () => {
+        await expectSaga(saveSettingsSaga, saveSettings(fakeSettings))
+            .withReducer(settingsReducer)
+            .provide([[matchers.call.fn(settingsStub.saveSettings), fakeSettings]])
+            .put(saveSettingsSuccess(fakeSettings))
+            .run();
+    });
+
+    it("puts notifyError + saveSettingsFailure on throw", async () => {
+        const result = await expectSaga(saveSettingsSaga, saveSettings(fakeSettings))
+            .withReducer(settingsReducer)
+            .provide([
+                [matchers.call.fn(settingsStub.saveSettings), throwError(new Error("bad"))],
+            ])
+            .put(notifyError({
+                messageKey: "errors.genericErrorWithMessage",
+                params: {message: "bad"},
+            }))
+            .put(saveSettingsFailure())
+            .run();
+
+        expect(result.storeState.isSaving).toBe(false);
+    });
+});

--- a/frontend/src/store/slices/settings/actions.ts
+++ b/frontend/src/store/slices/settings/actions.ts
@@ -9,7 +9,7 @@ export const SAVE_SETTINGS_SUCCESS = "settings/SAVE_SUCCESS";
 export const SAVE_SETTINGS_FAILURE = "settings/SAVE_FAILURE";
 
 export const CHECK_LLM = "settings/CHECK_LLM";
-export const CHECK_LLM_RESULT = "settings/CHECK_LLM_RESULT";
+export const CHECK_LLM_DONE = "settings/CHECK_LLM_DONE";
 
 export interface LoadSettingsAction {
     type: typeof LOAD_SETTINGS;
@@ -44,9 +44,8 @@ export interface CheckLlmAction {
     type: typeof CHECK_LLM;
 }
 
-export interface CheckLlmResultAction {
-    type: typeof CHECK_LLM_RESULT;
-    payload: { ok: boolean };
+export interface CheckLlmDoneAction {
+    type: typeof CHECK_LLM_DONE;
 }
 
 export type SettingsAction =
@@ -57,7 +56,7 @@ export type SettingsAction =
     | SaveSettingsSuccessAction
     | SaveSettingsFailureAction
     | CheckLlmAction
-    | CheckLlmResultAction;
+    | CheckLlmDoneAction;
 
 export const loadSettings = (): LoadSettingsAction => ({type: LOAD_SETTINGS});
 export const loadSettingsSuccess = (settings: AppSettings): LoadSettingsSuccessAction => ({
@@ -83,7 +82,4 @@ export const saveSettingsFailure = (message: string): SaveSettingsFailureAction 
 });
 
 export const checkLlm = (): CheckLlmAction => ({type: CHECK_LLM});
-export const checkLlmResult = (ok: boolean): CheckLlmResultAction => ({
-    type: CHECK_LLM_RESULT,
-    payload: {ok},
-});
+export const checkLlmDone = (): CheckLlmDoneAction => ({type: CHECK_LLM_DONE});

--- a/frontend/src/store/slices/settings/actions.ts
+++ b/frontend/src/store/slices/settings/actions.ts
@@ -22,7 +22,6 @@ export interface LoadSettingsSuccessAction {
 
 export interface LoadSettingsFailureAction {
     type: typeof LOAD_SETTINGS_FAILURE;
-    payload: string;
 }
 
 export interface SaveSettingsAction {
@@ -37,7 +36,6 @@ export interface SaveSettingsSuccessAction {
 
 export interface SaveSettingsFailureAction {
     type: typeof SAVE_SETTINGS_FAILURE;
-    payload: string;
 }
 
 export interface CheckLlmAction {
@@ -63,9 +61,8 @@ export const loadSettingsSuccess = (settings: AppSettings): LoadSettingsSuccessA
     type: LOAD_SETTINGS_SUCCESS,
     payload: settings,
 });
-export const loadSettingsFailure = (message: string): LoadSettingsFailureAction => ({
+export const loadSettingsFailure = (): LoadSettingsFailureAction => ({
     type: LOAD_SETTINGS_FAILURE,
-    payload: message,
 });
 
 export const saveSettings = (settings: AppSettings): SaveSettingsAction => ({
@@ -76,9 +73,8 @@ export const saveSettingsSuccess = (settings: AppSettings): SaveSettingsSuccessA
     type: SAVE_SETTINGS_SUCCESS,
     payload: settings,
 });
-export const saveSettingsFailure = (message: string): SaveSettingsFailureAction => ({
+export const saveSettingsFailure = (): SaveSettingsFailureAction => ({
     type: SAVE_SETTINGS_FAILURE,
-    payload: message,
 });
 
 export const checkLlm = (): CheckLlmAction => ({type: CHECK_LLM});

--- a/frontend/src/store/slices/settings/mutations.ts
+++ b/frontend/src/store/slices/settings/mutations.ts
@@ -15,12 +15,10 @@ export const applyLoaded = (state: SettingsState, settings: AppSettings): Settin
     ...state,
     settings,
     isLoading: false,
-    error: null,
 });
 
 export const applySaved = (state: SettingsState, settings: AppSettings): SettingsState => ({
     ...state,
     settings,
     isSaving: false,
-    error: null,
 });

--- a/frontend/src/store/slices/settings/mutations.ts
+++ b/frontend/src/store/slices/settings/mutations.ts
@@ -1,18 +1,14 @@
 import type {AppSettings} from "../../../domain/Settings";
 import type {SettingsState} from "./types";
 
-/**
- * Helpers that isolate non-trivial reducer slice transitions so the switch
- * statement stays readable.
- */
 export const markLlmProbing = (state: SettingsState): SettingsState => ({
     ...state,
-    llmProbe: {ok: state.llmProbe.ok, probing: true},
+    llmProbe: {probing: true},
 });
 
-export const settleLlmProbe = (state: SettingsState, ok: boolean): SettingsState => ({
+export const settleLlmProbing = (state: SettingsState): SettingsState => ({
     ...state,
-    llmProbe: {ok, probing: false},
+    llmProbe: {probing: false},
 });
 
 export const applyLoaded = (state: SettingsState, settings: AppSettings): SettingsState => ({

--- a/frontend/src/store/slices/settings/reducer.ts
+++ b/frontend/src/store/slices/settings/reducer.ts
@@ -2,7 +2,7 @@ import type {Reducer} from "redux";
 
 import {
     CHECK_LLM,
-    CHECK_LLM_RESULT,
+    CHECK_LLM_DONE,
     LOAD_SETTINGS,
     LOAD_SETTINGS_FAILURE,
     LOAD_SETTINGS_SUCCESS,
@@ -11,7 +11,7 @@ import {
     SAVE_SETTINGS_SUCCESS,
     type SettingsAction,
 } from "./actions";
-import {applyLoaded, applySaved, markLlmProbing, settleLlmProbe} from "./mutations";
+import {applyLoaded, applySaved, markLlmProbing, settleLlmProbing} from "./mutations";
 import {initialSettingsState, type SettingsState} from "./types";
 
 export const settingsReducer: Reducer<SettingsState> = (
@@ -36,8 +36,8 @@ export const settingsReducer: Reducer<SettingsState> = (
 
         case CHECK_LLM:
             return markLlmProbing(state);
-        case CHECK_LLM_RESULT:
-            return settleLlmProbe(state, typed.payload.ok);
+        case CHECK_LLM_DONE:
+            return settleLlmProbing(state);
 
         default:
             return state;

--- a/frontend/src/store/slices/settings/reducer.ts
+++ b/frontend/src/store/slices/settings/reducer.ts
@@ -21,18 +21,18 @@ export const settingsReducer: Reducer<SettingsState> = (
     const typed = action as SettingsAction;
     switch (typed.type) {
         case LOAD_SETTINGS:
-            return {...state, isLoading: true, error: null};
+            return {...state, isLoading: true};
         case LOAD_SETTINGS_SUCCESS:
             return applyLoaded(state, typed.payload);
         case LOAD_SETTINGS_FAILURE:
-            return {...state, isLoading: false, error: typed.payload};
+            return {...state, isLoading: false};
 
         case SAVE_SETTINGS:
-            return {...state, isSaving: true, error: null};
+            return {...state, isSaving: true};
         case SAVE_SETTINGS_SUCCESS:
             return applySaved(state, typed.payload);
         case SAVE_SETTINGS_FAILURE:
-            return {...state, isSaving: false, error: typed.payload};
+            return {...state, isSaving: false};
 
         case CHECK_LLM:
             return markLlmProbing(state);

--- a/frontend/src/store/slices/settings/saga/checkLlmSaga.ts
+++ b/frontend/src/store/slices/settings/saga/checkLlmSaga.ts
@@ -2,16 +2,23 @@ import {call, put, takeLatest} from "redux-saga/effects";
 import type {SagaIterator} from "redux-saga";
 
 import {apiFactory} from "../../../../api";
-import {CHECK_LLM, checkLlmResult} from "../actions";
+import {notifySuccess, notifyWarning} from "../../notifications";
+import {CHECK_LLM, checkLlmDone} from "../actions";
 
 export function* checkLlmSaga(): SagaIterator {
     const healthApi = apiFactory.createHealthApi();
+    let ok = false;
     try {
-        const ok: boolean = yield call([healthApi, healthApi.checkLlm]);
-        yield put(checkLlmResult(ok));
+        ok = yield call([healthApi, healthApi.checkLlm]);
     } catch {
-        yield put(checkLlmResult(false));
+        ok = false;
     }
+    if (ok) {
+        yield put(notifySuccess({messageKey: "settings.llmCheckSuccessToast"}));
+    } else {
+        yield put(notifyWarning({messageKey: "settings.llmCheckFailureToast"}));
+    }
+    yield put(checkLlmDone());
 }
 
 export function* watchCheckLlm(): SagaIterator {

--- a/frontend/src/store/slices/settings/saga/loadSettingsSaga.ts
+++ b/frontend/src/store/slices/settings/saga/loadSettingsSaga.ts
@@ -3,6 +3,7 @@ import type {SagaIterator} from "redux-saga";
 
 import {apiFactory} from "../../../../api";
 import type {AppSettings} from "../../../../domain/Settings";
+import {notifyError} from "../../notifications";
 import {LOAD_SETTINGS, loadSettingsFailure, loadSettingsSuccess} from "../actions";
 
 export function* loadSettingsSaga(): SagaIterator {
@@ -12,7 +13,11 @@ export function* loadSettingsSaga(): SagaIterator {
         yield put(loadSettingsSuccess(settings));
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        yield put(loadSettingsFailure(message));
+        yield put(notifyError({
+            messageKey: "errors.genericErrorWithMessage",
+            params: {message},
+        }));
+        yield put(loadSettingsFailure());
     }
 }
 

--- a/frontend/src/store/slices/settings/saga/saveSettingsSaga.ts
+++ b/frontend/src/store/slices/settings/saga/saveSettingsSaga.ts
@@ -3,6 +3,7 @@ import type {SagaIterator} from "redux-saga";
 
 import {apiFactory} from "../../../../api";
 import type {AppSettings} from "../../../../domain/Settings";
+import {notifyError} from "../../notifications";
 import {SAVE_SETTINGS, type SaveSettingsAction, saveSettingsFailure, saveSettingsSuccess,} from "../actions";
 
 export function* saveSettingsSaga(action: SaveSettingsAction): SagaIterator {
@@ -15,7 +16,11 @@ export function* saveSettingsSaga(action: SaveSettingsAction): SagaIterator {
         yield put(saveSettingsSuccess(saved));
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        yield put(saveSettingsFailure(message));
+        yield put(notifyError({
+            messageKey: "errors.genericErrorWithMessage",
+            params: {message},
+        }));
+        yield put(saveSettingsFailure());
     }
 }
 

--- a/frontend/src/store/slices/settings/selectors.ts
+++ b/frontend/src/store/slices/settings/selectors.ts
@@ -13,7 +13,6 @@ export const selectSettingsSaving = createSelector(
     selectSettingsState,
     (slice) => slice.isSaving,
 );
-export const selectSettingsError = createSelector(selectSettingsState, (slice) => slice.error);
 export const selectLlmProbing = createSelector(
     selectSettingsState,
     (slice) => slice.llmProbe.probing,

--- a/frontend/src/store/slices/settings/selectors.ts
+++ b/frontend/src/store/slices/settings/selectors.ts
@@ -14,4 +14,7 @@ export const selectSettingsSaving = createSelector(
     (slice) => slice.isSaving,
 );
 export const selectSettingsError = createSelector(selectSettingsState, (slice) => slice.error);
-export const selectLlmProbe = createSelector(selectSettingsState, (slice) => slice.llmProbe);
+export const selectLlmProbing = createSelector(
+    selectSettingsState,
+    (slice) => slice.llmProbe.probing,
+);

--- a/frontend/src/store/slices/settings/types.ts
+++ b/frontend/src/store/slices/settings/types.ts
@@ -5,7 +5,7 @@ export interface SettingsState {
     readonly isLoading: boolean;
     readonly isSaving: boolean;
     readonly error: string | null;
-    readonly llmProbe: { ok: boolean | null; probing: boolean };
+    readonly llmProbe: { probing: boolean };
 }
 
 export const initialSettingsState: SettingsState = {
@@ -13,5 +13,5 @@ export const initialSettingsState: SettingsState = {
     isLoading: false,
     isSaving: false,
     error: null,
-    llmProbe: {ok: null, probing: false},
+    llmProbe: {probing: false},
 };

--- a/frontend/src/store/slices/settings/types.ts
+++ b/frontend/src/store/slices/settings/types.ts
@@ -4,7 +4,6 @@ export interface SettingsState {
     readonly settings: AppSettings | null;
     readonly isLoading: boolean;
     readonly isSaving: boolean;
-    readonly error: string | null;
     readonly llmProbe: { probing: boolean };
 }
 
@@ -12,6 +11,5 @@ export const initialSettingsState: SettingsState = {
     settings: null,
     isLoading: false,
     isSaving: false,
-    error: null,
     llmProbe: {probing: false},
 };


### PR DESCRIPTION
## Summary

- Fixes toast re-firing on tab remount in Settings (LLM check) and Obsidian (applyLayout / bulkExport / setup).
- Root cause: redux slices stored one-shot operation results (`llmProbe.ok`, `lastApplyLayoutReport`, `lastBulkExportReport`, `lastSetupReport`, `settings.error`, `obsidian.error`). Components fired toasts via `useEffect` keyed on those fields. React Router unmounts/remounts features on nav, selector returned the same state, effect dependency unchanged, toast re-fired.
- Fix: new slice-less `notifications` saga in `frontend/src/store/slices/notifications/` (actions + single `takeEvery` listener → `toast.*(i18n.t(key, params))`). Domain sagas `put(notify*)` instead of persisting result fields. Result fields deleted from state. Follows the `frontend-scenarios-v2` `NotificationModel` pattern — one-shot events, not observable state.

## What changed

- New: `frontend/src/store/slices/notifications/` (actions, saga, tests).
- Each of 4 domain sagas (`checkLlmSaga`, `applyLayoutSaga`, `bulkExportSaga`, `setupObsidianSaga`) now dispatches `notifySuccess`/`notifyError`/`notifyWarning` with i18n keys. Two more sagas (`loadSettingsSaga`, `saveSettingsSaga`) dispatch `notifyError` on failure.
- `*_SUCCESS(payload)` / `*_FAILURE(message)` action pairs collapsed to `*_DONE` no-payload action per flow. Reducers now only flip progress flags.
- `useEffect`-driven toast blocks deleted from `Settings.tsx` and `Obsidian.tsx`. Event-handler toasts (`save()`, `applySetup()` validation) untouched — those are already one-shot.
- Locale additions (ru + en):
  - `settings.llmCheckSuccessToast` / `settings.llmCheckFailureToast` (replaces hardcoded `LLM: ✓/✗`)
  - `errors.genericErrorWithMessage` with `{{message}}` interpolation
- Spec for this change lives at `docs/agent-tasks/fix-stale-action-feedback.md` (committed in phase 0).

7 commits, one per phase. No squash — each phase stands on its own.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — 11 warnings, 0 errors (all pre-existing, unrelated)
- [x] `npm test` — 43 suites, 194 tests, 0 failed. +6 new test files (notifications saga, checkLlm, load/save settings sagas, apply/bulk/setup obsidian sagas)
- [x] Grep sweep (§11 of spec) — all 5 zero-hit targets met:
  - `lastApplyLayoutReport | lastBulkExportReport | lastSetupReport` — 0
  - `llmProbe\.ok | selectLlmProbe\b` — 0
  - `settleLlmProbe | CHECK_LLM_RESULT` — 0
  - `useEffect` with toast/error/report/llmProbe in Settings/Obsidian — 0
  - `toast\.` under `src/store/` — only inside `slices/notifications/`
- [ ] **Manual smoke in Electron — UNVERIFIED (sandbox cannot run the shell).** Compensated by the existing `Obsidian.test.tsx` component test which now includes `watchNotificationsSagas` and exercises the click → saga → notifySuccess → `toast.success` path end-to-end with `ToastContainer` mounted. Please smoke the 4 flows locally before merge:
  - Settings → «Проверить соединение» → toast. Tab away, tab back. No toast.
  - Obsidian → «Разложить по PARA» → toast. Tab away, tab back. No toast.
  - Obsidian → sync-all → toast. Same check.
  - Obsidian → setup → toast. Same check.

## Notes

- Spec minor deviations documented in the phase-6 report file (not in repo) and above: unified `*_DONE` naming across obsidian (vs keeping `*_FAILURE` suggested by spec §7.2); narrowed `llmProbe` struct with flat `selectLlmProbing` boolean exposed to container.