### PR TITLE
fix(python-sidecar): add pydantic-settings to prod requirements

### DIFF
--- a/python-sidecar/requirements.txt
+++ b/python-sidecar/requirements.txt
@@ -9,6 +9,8 @@
 fastapi>=0.115.0
 uvicorn[standard]>=0.32.0
 python-multipart>=0.0.18
+pydantic>=2.0
+pydantic-settings>=2.0
 
 # --- ML runtime ---
 # torch pulls ~4GB of CUDA wheels on Linux by default — overkill for the


### PR DESCRIPTION
## Problem

Fresh venvs built from `python-sidecar/requirements.txt` can't start:

```
File "/.../python-sidecar/app/config.py", line 11, in <module>
    from pydantic_settings import BaseSettings, SettingsConfigDict
ModuleNotFoundError: No module named 'pydantic_settings'
```

`requirements.txt` relies on `fastapi` to transitively pull `pydantic`, but the separate `pydantic-settings` package is never declared — so prod-style installs fail, while dev installs (`requirements-dev.txt`) succeed because that file does list both packages explicitly.

## Fix

Add `pydantic>=2.0` and `pydantic-settings>=2.0` to the Web framework section of `requirements.txt`, matching what `requirements-dev.txt` already has.

## Verification

- `scripts/demo.command` rebuilds the venv when the requirements hash changes → next launch will pull `pydantic-settings`.
- Manual unblock on an already-built venv: `.venv/bin/pip install pydantic-settings`.