### PR TITLE
feat(obsidian): ADR-019 frontend — diagnostics view + empty-state banner (MR 3/3)

### DIFF
--- a/docs/NEXT_OBSIDIAN.md
+++ b/docs/NEXT_OBSIDIAN.md
@@ -1,0 +1,87 @@
+---
+title: Obsidian — deferred follow-ups after ADR-019
+status: Planned
+date: 2026-04-23
+related: [ADR-019-obsidian-optional-sidecar]
+authors: [shuka]
+---
+
+# Obsidian — что осталось после ADR-019
+
+ADR-019 уехал тремя MR'ами: #48 (skeleton), #49 (backend drivers + endpoints + feature flag), #50 (frontend diagnostics + empty-state). Ниже — пункты, которые сознательно ушли в follow-up и их не надо терять.
+
+## 1. Wizard-stepper (5-step first-run онбординг)
+
+**Контекст.** ADR-019 §5.7 описывает стейт-машину из 5 шагов: (1) выбор/подтверждение vault path, (2) установка плагинов, (3) пользователь включает плагины в Obsidian (мы поллим), (4) чтение REST-токена из `plugins/obsidian-local-rest-api/data.json`, (5) установка bootstrap + Templater preset.
+
+**Почему отложили.** Текущий Diagnostics-вид + кнопки «Reinstall plugins» + «Reapply templates» делают то же самое в один клик. Wizard добавит UX сопровождения, но это большой объём state-machine и резьба поверх кнопок, которые уже работают. Сначала — пощупать diagnostics в реальной жизни, потом решать что делать дальше.
+
+**Что нужно (когда возьмём).**
+- Endpoints `POST /api/obsidian/wizard/start` + `POST /api/obsidian/wizard/step/{n}`. Идемпотентные; реентрантные: состояние живёт в `VaultDiagnosticsReport`, не в отдельной wizard-таблице.
+- Шаг 4: polling `data.json` до 30s, запись токена в `IAppSettings.ObsidianApiToken`.
+- Frontend: `<ObsidianWizard />` stepper, саги `wizardSaga.ts`, UI-переключение между Wizard и Diagnostics по `diagnostics.vault.ok`.
+- i18n: `obsidian.wizard.step.<n>.title|action`.
+
+## 2. `ProcessedNoteSaved` publisher + `ObsidianDomainEventHandler`
+
+**Контекст.** ADR-019 §5.5 — главная идея: sidecar не блокирует основной пайплайн. После сохранения `ProcessedNote` публикуется domain event; sidecar-consumer асинхронно экспортирует ноту через `IVaultDriver.WriteNoteAsync`.
+
+**Почему отложили.** Требует аккуратной правки `ProcessQueueWorker` — единственная точка касания основного пайплайна, и CLAUDE.md §0 ADR-019 требует Draft MR + ревью до мёржа. Не хотелось смешивать это с инфраструктурной MR #49.
+
+**Что нужно.**
+- `IDomainEventBus` имплементация на `Channel<T>` fan-out (паттерн `IJobProgressNotifier` в `ChannelJobProgressNotifier`).
+- Публикация `new ProcessedNoteSaved(noteId, profileId, DateTimeOffset.UtcNow)` в одной строке: там, где сейчас выставляется `ProcessedNote.ExportedToVault = true` или при первой записи `ProcessedNote` в БД.
+- `ObsidianDomainEventHandler` — subscriber, кладёт в bounded `Channel<VaultNoteWrite>` (cap 128, `BoundedChannelFullMode.DropOldest`).
+- `ObsidianExportBackgroundService : BackgroundService` — читает канал, вызывает `IVaultDriver.WriteNoteAsync`. Провалы → Serilog warn + `MozgoslavMetrics.ObsidianExportFailure.Inc()`. Не ретёрнит наверх, не останавливает основной пайплайн.
+- Gate на `IAppSettings.ObsidianFeatureEnabled`: при `false` handler — no-op.
+- Тест: `ProcessQueueWorker` завершает работу за секунду даже когда Obsidian недоступен (vault path пустой, никаких плагинов) — нулевой latency-impact.
+
+## 3. Downscope `ObsidianRestApiClient`
+
+**Контекст.** ADR-019 §5.4: `FileSystemVaultDriver` — единственный writer. REST-клиент должен держать только read-only методы: `IsReachableAsync`, `OpenNoteAsync`, `GetVaultInfoAsync`. `EnsureFolderAsync` должен уйти.
+
+**Почему отложили.** `ObsidianRestApiClientTests` (WireMock) имеет тест `EnsureFolderAsync_PutsWithTrailingSlash`. Его удаление = collateral test edit. Держали MR'ы чистыми.
+
+**Что нужно.**
+- Удалить `Task EnsureFolderAsync(...)` из `IObsidianRestClient` + имплементации в `ObsidianRestApiClient`.
+- Удалить тест `EnsureFolderAsync_PutsWithTrailingSlash` в `ObsidianRestApiClientTests`.
+- Проверить grep по `EnsureFolderAsync` — не должно остаться call site'ов.
+
+## 4. Flip test scaffolds (`Assert.Inconclusive` → real assertions)
+
+**Контекст.** В #48 легли unit + integration скаффолды с `Assert.Inconclusive("pending impl — MR2 Commit …")` для каждой сценарной ячейки: `FileSystemVaultDriver`, `VaultDiagnosticsService`, `GitHubPluginInstaller`, `EmbeddedVaultBootstrap`, `VaultSidecarOrchestrator`, `ObsidianWizardEndpointTests`, `ObsidianDiagnosticsEndpointTests`, `FeatureDisabledTests`.
+
+**Почему отложили.** Инфраструктура приземлилась в #49, но заменять Inconclusive'ы на реальные assertion'ы — отдельный objёмный виток (сотни строк тестов).
+
+**Что нужно.** По каждому файлу:
+- Unit-тесты `FileSystemVaultDriver`: реальные сценарии через temp dir (`ITestDirectory` helper), SHA-256 drift, backup под `<vault>/.mozgoslav/bootstrap-backups/<iso>/`, path-escape guard, UserOwned preserve, cancellation.
+- `VaultDiagnosticsService`: каждое поле чипа через synthetic vault с разными состояниями `.obsidian/plugins/`, `community-plugins.json`, `data.json`.
+- `GitHubPluginInstaller`: HTTP-moked через `HttpMessageHandler`-stub. SHA match / mismatch / 404 / timeout. Atomic swap cleanup на failure.
+- `EmbeddedVaultBootstrap`: прочитать каждый embedded resource, сверить SHA с `manifest.json`, убедиться что `Manifest` — тот же инстанс на повторном чтении.
+- `VaultSidecarOrchestrator`: happy path + failure branches через фейковые `IVaultDriver` / `IPluginInstaller`.
+- `ObsidianWizardEndpointTests`: когда wizard появится (см. §1). До тех пор — оставить Inconclusive.
+- `ObsidianDiagnosticsEndpointTests`: дёрнуть `GET /api/obsidian/diagnostics`, проверить shape. `FeatureDisabledTests`: 503 на всех write endpoint'ах при `ObsidianFeatureEnabled=false`, `GET diagnostics` всегда отвечает.
+
+## 5. Telemetry — OTel counters
+
+**Контекст.** ADR-019 §9 D7 просил: `MozgoslavMetrics.ObsidianExportAttempted`, `ObsidianExportFailure`, `ObsidianDiagnosticsCheck{check,ok}`, `ObsidianWizardStep{step,result}`.
+
+**Почему отложили.** Диагностика работает без метрик; лучше добавить когда появится event-bus (§2) и wizard (§1), чтобы инструментировать то, что реально исполняется.
+
+**Что нужно.** `MozgoslavMetrics` (`Mozgoslav.Infrastructure/Observability/MozgoslavMetrics.cs`) — добавить счётчики по паттерну существующих метрик. Зарегистрировать в OTel exporter'е. Эмитить из `ObsidianDomainEventHandler`, `VaultDiagnosticsService.RunAsync`, wizard endpoint'ах.
+
+## 6. D4 smoke test — macOS
+
+ADR-019 §9 D4.1–D4.4 — ручные smoke-шаги на реальной макбуке. Инструкции уже в ADR; надо пройти и записать результат:
+- D4.1: Fresh empty folder → wizard (или через diagnostics + reinstall) → плагины установлены → REST token подхвачен → bootstrap в vault → «Sync All» → note в vault → открыть через REST.
+- D4.2: `ObsidianFeatureEnabled=false` → вкладка Obsidian показывает «Feature disabled» → основной пайплайн обрабатывает запись без единого Obsidian-вызова (Serilog подтверждает).
+- D4.3: удалить `_system/scripts/split_and_label.js` из vault → diagnostics флагит `Bootstrap.Outdated` → `Reapply bootstrap` восстанавливает → user-edits в `_system/corrections.md` сохранены.
+- D4.4: ротация REST token внутри Obsidian → diagnostics флагит `RestApi.TokenMismatch` → handler `RefreshRestToken` возвращает зелёный статус.
+
+## 7. Опционально — per-profile Templater templates
+
+ADR-019 §N6: один `_system/templates/split-and-label.md` + один `Templates/Mozgoslav Conversation.md`. Когда появится potreb в разных профилях («рабочий» / «неформальный») — размножить шаблоны и положить под `_system/templates/<profile>/`, Templater подхватит автоматически.
+
+## 8. Опционально — import from vault обратно в Mozgoslav
+
+ADR-019 §N4: сейчас одна сторона — mozgoslav пишет в vault. Обратный poll (что руками поправили в vault → подтянуть в БД) — отдельная история, свой ADR.

--- a/frontend/src/api/ObsidianApi.ts
+++ b/frontend/src/api/ObsidianApi.ts
@@ -7,6 +7,8 @@ export interface ObsidianSetupReport {
 
 export interface ObsidianBulkExportResult {
     readonly exportedCount: number;
+    readonly skippedCount: number;
+    readonly failures: ReadonlyArray<{ noteId: string; reason: string }>;
 }
 
 export interface ObsidianApplyLayoutResult {
@@ -24,6 +26,118 @@ export interface ObsidianRestHealth {
     readonly host: string;
     readonly version: string | null;
     readonly diagnostic: string;
+}
+
+export type DiagnosticAction =
+    | "OpenOnboarding"
+    | "ReinstallPlugins"
+    | "ReapplyBootstrap"
+    | "RefreshRestToken"
+    | "OpenLmStudioHelp"
+    | "OpenSettings";
+
+export type CheckSeverity = "Ok" | "Advisory" | "Warning" | "Error";
+
+export interface VaultPathCheck {
+    readonly ok: boolean;
+    readonly severity: CheckSeverity;
+    readonly code: string;
+    readonly message: string;
+    readonly actions: readonly DiagnosticAction[];
+    readonly vaultPath: string;
+}
+
+export interface PluginCheck {
+    readonly pluginId: string;
+    readonly installed: boolean;
+    readonly enabled: boolean;
+    readonly hashMatches: boolean;
+    readonly optional: boolean;
+    readonly expectedVersion: string;
+    readonly installedVersion: string | null;
+    readonly severity: CheckSeverity;
+    readonly code: string;
+    readonly message: string;
+    readonly actions: readonly DiagnosticAction[];
+    readonly ok: boolean;
+}
+
+export interface TemplaterSettingsCheck {
+    readonly ok: boolean;
+    readonly severity: CheckSeverity;
+    readonly code: string;
+    readonly message: string;
+    readonly actions: readonly DiagnosticAction[];
+    readonly templatesFolder: string | null;
+    readonly userScriptsFolder: string | null;
+}
+
+export interface BootstrapFileDrift {
+    readonly vaultRelativePath: string;
+    readonly status: "Ok" | "Missing" | "Outdated" | "UserModified" | "Extra";
+    readonly expectedSha256: string;
+    readonly actualSha256: string | null;
+}
+
+export interface BootstrapDriftCheck {
+    readonly ok: boolean;
+    readonly severity: CheckSeverity;
+    readonly code: string;
+    readonly message: string;
+    readonly actions: readonly DiagnosticAction[];
+    readonly files: readonly BootstrapFileDrift[];
+}
+
+export interface RestApiCheck {
+    readonly ok: boolean;
+    readonly required: boolean;
+    readonly severity: CheckSeverity;
+    readonly code: string;
+    readonly message: string;
+    readonly actions: readonly DiagnosticAction[];
+    readonly host: string | null;
+    readonly version: string | null;
+}
+
+export interface LmStudioCheck {
+    readonly ok: boolean;
+    readonly severity: CheckSeverity;
+    readonly code: string;
+    readonly message: string;
+    readonly actions: readonly DiagnosticAction[];
+    readonly endpoint: string | null;
+}
+
+export interface VaultDiagnosticsReport {
+    readonly snapshotId: string;
+    readonly vault: VaultPathCheck;
+    readonly plugins: readonly PluginCheck[];
+    readonly templater: TemplaterSettingsCheck;
+    readonly bootstrap: BootstrapDriftCheck;
+    readonly restApi: RestApiCheck;
+    readonly lmStudio: LmStudioCheck;
+    readonly generatedAt: string;
+    readonly isHealthy: boolean;
+}
+
+export interface ObsidianReinstallResult {
+    readonly plugins: ReadonlyArray<{
+        readonly pluginId: string;
+        readonly status: string;
+        readonly message: string | null;
+        readonly writtenFiles: readonly string[];
+    }>;
+    readonly report: VaultDiagnosticsReport;
+}
+
+export interface ObsidianReapplyResult {
+    readonly report: VaultDiagnosticsReport;
+}
+
+export interface ObsidianBulkExportError {
+    readonly error: string;
+    readonly hint: string;
+    readonly actions: readonly DiagnosticAction[];
 }
 
 export class ObsidianApi extends BaseApi {
@@ -54,6 +168,21 @@ export class ObsidianApi extends BaseApi {
 
     public async restHealth(): Promise<ObsidianRestHealth> {
         const response = await this.get<ObsidianRestHealth>("/api/obsidian/rest-health");
+        return response.data;
+    }
+
+    public async diagnostics(): Promise<VaultDiagnosticsReport> {
+        const response = await this.get<VaultDiagnosticsReport>(API_ENDPOINTS.obsidianDiagnostics);
+        return response.data;
+    }
+
+    public async reapplyBootstrap(): Promise<ObsidianReapplyResult> {
+        const response = await this.post<ObsidianReapplyResult>(API_ENDPOINTS.obsidianReapplyBootstrap);
+        return response.data;
+    }
+
+    public async reinstallPlugins(): Promise<ObsidianReinstallResult> {
+        const response = await this.post<ObsidianReinstallResult>(API_ENDPOINTS.obsidianReinstallPlugins);
         return response.data;
     }
 }

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -40,6 +40,9 @@ export const API_ENDPOINTS = {
     obsidianSetup: "/api/obsidian/setup",
     obsidianExportAll: "/api/obsidian/export-all",
     obsidianApplyLayout: "/api/obsidian/apply-layout",
+    obsidianDiagnostics: "/api/obsidian/diagnostics",
+    obsidianReapplyBootstrap: "/api/obsidian/reapply-bootstrap",
+    obsidianReinstallPlugins: "/api/obsidian/reinstall-plugins",
 
     logs: "/api/logs",
     logsTail: "/api/logs/tail",

--- a/frontend/src/features/Obsidian/Obsidian.container.ts
+++ b/frontend/src/features/Obsidian/Obsidian.container.ts
@@ -5,8 +5,16 @@ import type {GlobalState} from "../../store";
 import {
     applyLayout,
     bulkExport,
+    fetchDiagnostics,
+    reapplyBootstrap,
+    reinstallPlugins,
+    selectObsidianDiagnostics,
+    selectObsidianDiagnosticsError,
+    selectObsidianDiagnosticsLoading,
     selectObsidianIsApplyingLayout,
     selectObsidianIsBulkExporting,
+    selectObsidianIsReapplyingBootstrap,
+    selectObsidianIsReinstallingPlugins,
     selectObsidianIsSetupInProgress,
     setupObsidian,
 } from "../../store/slices/obsidian";
@@ -19,6 +27,11 @@ const mapStateToProps = (state: GlobalState): ObsidianStateProps => ({
     isBulkExporting: selectObsidianIsBulkExporting(state),
     isApplyingLayout: selectObsidianIsApplyingLayout(state),
     isSetupInProgress: selectObsidianIsSetupInProgress(state),
+    diagnostics: selectObsidianDiagnostics(state),
+    isDiagnosticsLoading: selectObsidianDiagnosticsLoading(state),
+    diagnosticsError: selectObsidianDiagnosticsError(state),
+    isReapplyingBootstrap: selectObsidianIsReapplyingBootstrap(state),
+    isReinstallingPlugins: selectObsidianIsReinstallingPlugins(state),
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): ObsidianDispatchProps =>
@@ -29,6 +42,9 @@ const mapDispatchToProps = (dispatch: Dispatch): ObsidianDispatchProps =>
             onSetup: setupObsidian,
             onBulkExport: bulkExport,
             onApplyLayout: applyLayout,
+            onFetchDiagnostics: fetchDiagnostics,
+            onReapplyBootstrap: reapplyBootstrap,
+            onReinstallPlugins: reinstallPlugins,
         },
         dispatch,
     );

--- a/frontend/src/features/Obsidian/Obsidian.style.ts
+++ b/frontend/src/features/Obsidian/Obsidian.style.ts
@@ -80,3 +80,54 @@ export const BulkButtonRow = styled.div`
     gap: ${({theme}) => theme.space(2)};
     flex-wrap: wrap;
 `;
+
+export const DiagnosticsGrid = styled.div`
+    display: grid;
+    gap: ${({theme}) => theme.space(2)};
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+`;
+
+export const DiagnosticsChip = styled.div<{ $severity: "Ok" | "Advisory" | "Warning" | "Error" }>`
+    display: flex;
+    flex-direction: column;
+    gap: ${({theme}) => theme.space(1)};
+    padding: ${({theme}) => theme.space(3)};
+    background: ${({theme}) => theme.colors.bg.elevated2};
+    border: 1px solid ${({theme, $severity}) => {
+        switch ($severity) {
+            case "Ok": return theme.colors.accent.primary;
+            case "Advisory": return theme.colors.border.subtle;
+            case "Warning": return theme.colors.warning;
+            case "Error": return theme.colors.error;
+            default: return theme.colors.border.subtle;
+        }
+    }};
+    border-radius: ${({theme}) => theme.radii.md};
+    font-size: ${({theme}) => theme.font.size.sm};
+    color: ${({theme}) => theme.colors.text.primary};
+`;
+
+export const DiagnosticsChipTitle = styled.strong`
+    display: flex;
+    align-items: center;
+    gap: ${({theme}) => theme.space(1)};
+    font-size: ${({theme}) => theme.font.size.md};
+    color: ${({theme}) => theme.colors.text.primary};
+`;
+
+export const DiagnosticsChipMessage = styled.span`
+    font-size: ${({theme}) => theme.font.size.sm};
+    color: ${({theme}) => theme.colors.text.secondary};
+    line-height: 1.4;
+`;
+
+export const EmptyStateBanner = styled.div`
+    display: flex;
+    align-items: center;
+    gap: ${({theme}) => theme.space(3)};
+    padding: ${({theme}) => theme.space(3)};
+    background: ${({theme}) => theme.colors.bg.elevated2};
+    border: 1px solid ${({theme}) => theme.colors.border.subtle};
+    border-radius: ${({theme}) => theme.radii.md};
+    color: ${({theme}) => theme.colors.text.primary};
+`;

--- a/frontend/src/features/Obsidian/Obsidian.tsx
+++ b/frontend/src/features/Obsidian/Obsidian.tsx
@@ -1,21 +1,36 @@
 import {FC, useEffect, useMemo, useState} from "react";
 import {useTranslation} from "react-i18next";
 import {toast} from "react-toastify";
-import {CheckCircle2, Circle, FolderTree, LayoutTemplate, UploadCloud} from "lucide-react";
+import {
+    AlertTriangle,
+    CheckCircle2,
+    Circle,
+    FolderTree,
+    LayoutTemplate,
+    RefreshCw,
+    ShieldCheck,
+    UploadCloud,
+} from "lucide-react";
 
 import Button from "../../components/Button";
 import Card from "../../components/Card";
 import {AppSettings, DEFAULT_SETTINGS} from "../../domain/Settings";
+import type {CheckSeverity} from "../../api/ObsidianApi";
 import type {ObsidianProps} from "./types";
 import {
     BulkButtonRow,
+    DiagnosticsChip,
+    DiagnosticsChipMessage,
+    DiagnosticsChipTitle,
+    DiagnosticsGrid,
+    EmptyStateBanner,
     FolderGrid,
     FolderHint,
     FolderItem,
     PageRoot,
     PageTitle,
     Subtitle,
-    VaultRow
+    VaultRow,
 } from "./Obsidian.style";
 
 const PRESET_FOLDERS = [
@@ -32,11 +47,19 @@ const Obsidian: FC<ObsidianProps> = ({
                                          isBulkExporting,
                                          isApplyingLayout,
                                          isSetupInProgress,
+                                         diagnostics,
+                                         isDiagnosticsLoading,
+                                         diagnosticsError,
+                                         isReapplyingBootstrap,
+                                         isReinstallingPlugins,
                                          onLoadSettings,
                                          onSaveSettings,
                                          onSetup,
                                          onBulkExport,
                                          onApplyLayout,
+                                         onFetchDiagnostics,
+                                         onReapplyBootstrap,
+                                         onReinstallPlugins,
                                      }) => {
     const {t} = useTranslation();
     const [settings, setSettings] = useState<AppSettings>(loadedSettings ?? DEFAULT_SETTINGS);
@@ -47,6 +70,10 @@ const Obsidian: FC<ObsidianProps> = ({
     useEffect(() => {
         onLoadSettings();
     }, [onLoadSettings]);
+
+    useEffect(() => {
+        onFetchDiagnostics();
+    }, [onFetchDiagnostics]);
 
     useEffect(() => {
         if (loadedSettings) setSettings(loadedSettings);
@@ -82,12 +109,24 @@ const Obsidian: FC<ObsidianProps> = ({
 
     const selectedArray = useMemo(() => Array.from(selected), [selected]);
 
+    const vaultMissing = !settings.vaultPath;
+
     return (
         <PageRoot>
             <div>
                 <PageTitle>{t("obsidian.title")}</PageTitle>
                 <Subtitle>{t("obsidian.setupHint")}</Subtitle>
             </div>
+
+            {vaultMissing && (
+                <EmptyStateBanner data-testid="obsidian-empty-state">
+                    <AlertTriangle size={18}/>
+                    <div>
+                        <strong>{t("obsidian.emptyState.vault-not-configured")}</strong>
+                        <FolderHint>{t("obsidian.emptyState.vaultHint")}</FolderHint>
+                    </div>
+                </EmptyStateBanner>
+            )}
 
             <Card title={t("settings.fields.vaultPath")}>
                 <VaultRow>
@@ -157,8 +196,97 @@ const Obsidian: FC<ObsidianProps> = ({
                     </Button>
                 </div>
             </Card>
+
+            <Card
+                title={t("obsidian.diagnostics.title")}
+                subtitle={t("obsidian.diagnostics.subtitle")}
+            >
+                <BulkButtonRow>
+                    <Button
+                        variant="secondary"
+                        leftIcon={<RefreshCw size={16}/>}
+                        isLoading={isDiagnosticsLoading}
+                        onClick={onFetchDiagnostics}
+                        data-testid="obsidian-refresh-diagnostics"
+                    >
+                        {t("obsidian.diagnostics.refresh")}
+                    </Button>
+                    <Button
+                        variant="secondary"
+                        leftIcon={<ShieldCheck size={16}/>}
+                        isLoading={isReapplyingBootstrap}
+                        disabled={!settings.vaultPath}
+                        onClick={onReapplyBootstrap}
+                        data-testid="obsidian-reapply-bootstrap"
+                    >
+                        {t("obsidian.diagnostics.reapplyBootstrap")}
+                    </Button>
+                    <Button
+                        variant="secondary"
+                        leftIcon={<LayoutTemplate size={16}/>}
+                        isLoading={isReinstallingPlugins}
+                        disabled={!settings.vaultPath}
+                        onClick={onReinstallPlugins}
+                        data-testid="obsidian-reinstall-plugins"
+                    >
+                        {t("obsidian.diagnostics.reinstallPlugins")}
+                    </Button>
+                </BulkButtonRow>
+                {diagnosticsError && (
+                    <FolderHint data-testid="obsidian-diagnostics-error">
+                        {diagnosticsError}
+                    </FolderHint>
+                )}
+                {diagnostics && (
+                    <DiagnosticsGrid data-testid="obsidian-diagnostics-grid">
+                        <Chip
+                            label={t("obsidian.diagnostics.vault")}
+                            severity={diagnostics.vault.severity}
+                            message={diagnostics.vault.message}
+                        />
+                        {diagnostics.plugins.map((plugin) => (
+                            <Chip
+                                key={plugin.pluginId}
+                                label={plugin.pluginId}
+                                severity={plugin.severity}
+                                message={plugin.message}
+                            />
+                        ))}
+                        <Chip
+                            label={t("obsidian.diagnostics.templater")}
+                            severity={diagnostics.templater.severity}
+                            message={diagnostics.templater.message}
+                        />
+                        <Chip
+                            label={t("obsidian.diagnostics.bootstrap")}
+                            severity={diagnostics.bootstrap.severity}
+                            message={diagnostics.bootstrap.message}
+                        />
+                        <Chip
+                            label={t("obsidian.diagnostics.restApi")}
+                            severity={diagnostics.restApi.severity}
+                            message={diagnostics.restApi.message}
+                        />
+                        <Chip
+                            label={t("obsidian.diagnostics.lmStudio")}
+                            severity={diagnostics.lmStudio.severity}
+                            message={diagnostics.lmStudio.message}
+                        />
+                    </DiagnosticsGrid>
+                )}
+            </Card>
         </PageRoot>
     );
 };
+
+const Chip: FC<{ label: string; severity: CheckSeverity; message: string }> = ({label, severity, message}) => (
+    <DiagnosticsChip $severity={severity} data-testid={`obsidian-chip-${severity}`}>
+        <DiagnosticsChipTitle>
+            {severity === "Ok" ? <CheckCircle2 size={16}/> : <AlertTriangle size={16}/>}
+            {label}
+        </DiagnosticsChipTitle>
+        <DiagnosticsChipMessage>{message}</DiagnosticsChipMessage>
+    </DiagnosticsChip>
+);
 
 export default Obsidian;

--- a/frontend/src/features/Obsidian/__tests__/Obsidian.test.tsx
+++ b/frontend/src/features/Obsidian/__tests__/Obsidian.test.tsx
@@ -48,7 +48,7 @@ describe("Obsidian — first-class tab (BC-025 / Bug 22)", () => {
     });
 
     it("Obsidian_SyncAll_CallsBulkExport", async () => {
-        mockApi.obsidianApi.bulkExport.mockResolvedValue({exportedCount: 3});
+        mockApi.obsidianApi.bulkExport.mockResolvedValue({exportedCount: 3, skippedCount: 0, failures: []});
 
         renderObsidian();
 

--- a/frontend/src/features/Obsidian/types.ts
+++ b/frontend/src/features/Obsidian/types.ts
@@ -1,10 +1,16 @@
 import type {AppSettings} from "../../domain/Settings";
+import type {VaultDiagnosticsReport} from "../../api/ObsidianApi";
 
 export interface ObsidianStateProps {
     readonly settings: AppSettings | null;
     readonly isBulkExporting: boolean;
     readonly isApplyingLayout: boolean;
     readonly isSetupInProgress: boolean;
+    readonly diagnostics: VaultDiagnosticsReport | null;
+    readonly isDiagnosticsLoading: boolean;
+    readonly diagnosticsError: string | null;
+    readonly isReapplyingBootstrap: boolean;
+    readonly isReinstallingPlugins: boolean;
 }
 
 export interface ObsidianDispatchProps {
@@ -13,6 +19,9 @@ export interface ObsidianDispatchProps {
     readonly onSetup: (vaultPath?: string) => void;
     readonly onBulkExport: () => void;
     readonly onApplyLayout: () => void;
+    readonly onFetchDiagnostics: () => void;
+    readonly onReapplyBootstrap: () => void;
+    readonly onReinstallPlugins: () => void;
 }
 
 export type ObsidianProps = ObsidianStateProps & ObsidianDispatchProps;

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -299,8 +299,30 @@
     "bulkExportHint": "Push any un-exported notes into your vault and lay them out using PARA.",
     "syncAll": "Sync all un-exported notes",
     "syncAllSuccess": "Exported notes: {{count}}",
+    "syncAllUpToDate": "Already in sync ({{count}} notes skipped)",
     "applyLayout": "Apply PARA layout",
-    "applyLayoutSuccess": "Folders created: {{folders}}, notes moved: {{notes}}"
+    "applyLayoutSuccess": "Folders created: {{folders}}, notes moved: {{notes}}",
+    "emptyState": {
+      "vault-not-configured": "Vault not configured",
+      "plugins-missing": "Obsidian plugins are not installed",
+      "obsidian-feature-disabled": "Obsidian integration is disabled in Settings",
+      "export-failed": "Export failed: {{hint}}",
+      "vaultHint": "Point Mozgoslav at your Obsidian vault to start syncing."
+    },
+    "diagnostics": {
+      "title": "Integration diagnostics",
+      "subtitle": "At-a-glance view of what's connected, missing, or drifted.",
+      "refresh": "Refresh",
+      "reapplyBootstrap": "Reapply templates",
+      "reinstallPlugins": "Reinstall plugins",
+      "reapplyBootstrapSuccess": "Templates and scripts restored from the shipped version.",
+      "reinstallPluginsSuccess": "Plugins reinstalled: {{count}}",
+      "vault": "Vault",
+      "templater": "Templater",
+      "bootstrap": "Templates / scripts",
+      "restApi": "Local REST API",
+      "lmStudio": "LM Studio"
+    }
   },
   "onboarding": {
     "title": "Welcome to Mozgoslav",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -299,8 +299,30 @@
     "bulkExportHint": "Прогнать все не-экспортированные заметки и разложить их по PARA.",
     "syncAll": "Выгрузить все новые заметки",
     "syncAllSuccess": "Экспортировано заметок: {{count}}",
+    "syncAllUpToDate": "Всё уже в vault'е ({{count}} заметок пропущено)",
     "applyLayout": "Разложить по PARA",
-    "applyLayoutSuccess": "Создано папок: {{folders}}, перемещено заметок: {{notes}}"
+    "applyLayoutSuccess": "Создано папок: {{folders}}, перемещено заметок: {{notes}}",
+    "emptyState": {
+      "vault-not-configured": "Vault не настроен",
+      "plugins-missing": "Плагины Obsidian не установлены",
+      "obsidian-feature-disabled": "Интеграция с Obsidian выключена в настройках",
+      "export-failed": "Экспорт не удался: {{hint}}",
+      "vaultHint": "Укажи путь к Obsidian vault в настройках, чтобы начать синхронизацию."
+    },
+    "diagnostics": {
+      "title": "Диагностика интеграции",
+      "subtitle": "Одним взглядом — что подключено, что отсутствует, что обновлено.",
+      "refresh": "Обновить",
+      "reapplyBootstrap": "Переустановить шаблоны",
+      "reinstallPlugins": "Переустановить плагины",
+      "reapplyBootstrapSuccess": "Шаблоны и скрипты восстановлены из версии приложения.",
+      "reinstallPluginsSuccess": "Плагинов переустановлено: {{count}}",
+      "vault": "Vault",
+      "templater": "Templater",
+      "bootstrap": "Шаблоны / скрипты",
+      "restApi": "Local REST API",
+      "lmStudio": "LM Studio"
+    }
   },
   "onboarding": {
     "title": "Добро пожаловать в Мозгослав",

--- a/frontend/src/store/slices/obsidian/__tests__/bulkExportSaga.test.ts
+++ b/frontend/src/store/slices/obsidian/__tests__/bulkExportSaga.test.ts
@@ -32,7 +32,7 @@ describe("bulkExportSaga", () => {
     beforeEach(() => jest.clearAllMocks());
 
     it("emits notifySuccess + BULK_EXPORT_DONE on happy path", async () => {
-        const report: ObsidianBulkExportReport = {exportedCount: 42};
+        const report: ObsidianBulkExportReport = {exportedCount: 42, skippedCount: 0};
         const result = await expectSaga(bulkExportSaga)
             .withReducer(obsidianReducer)
             .provide([[matchers.call.fn(obsidianStub.bulkExport), report]])

--- a/frontend/src/store/slices/obsidian/actions.ts
+++ b/frontend/src/store/slices/obsidian/actions.ts
@@ -1,3 +1,5 @@
+import type {VaultDiagnosticsReport} from "../../../api/ObsidianApi";
+
 export const SETUP_OBSIDIAN = "obsidian/SETUP";
 export const SETUP_OBSIDIAN_DONE = "obsidian/SETUP_DONE";
 
@@ -6,6 +8,16 @@ export const BULK_EXPORT_DONE = "obsidian/BULK_EXPORT_DONE";
 
 export const APPLY_LAYOUT = "obsidian/APPLY_LAYOUT";
 export const APPLY_LAYOUT_DONE = "obsidian/APPLY_LAYOUT_DONE";
+
+export const FETCH_DIAGNOSTICS = "obsidian/FETCH_DIAGNOSTICS";
+export const FETCH_DIAGNOSTICS_DONE = "obsidian/FETCH_DIAGNOSTICS_DONE";
+export const FETCH_DIAGNOSTICS_FAILED = "obsidian/FETCH_DIAGNOSTICS_FAILED";
+
+export const REAPPLY_BOOTSTRAP = "obsidian/REAPPLY_BOOTSTRAP";
+export const REAPPLY_BOOTSTRAP_DONE = "obsidian/REAPPLY_BOOTSTRAP_DONE";
+
+export const REINSTALL_PLUGINS = "obsidian/REINSTALL_PLUGINS";
+export const REINSTALL_PLUGINS_DONE = "obsidian/REINSTALL_PLUGINS_DONE";
 
 export interface SetupObsidianAction {
     type: typeof SETUP_OBSIDIAN;
@@ -32,13 +44,50 @@ export interface ApplyLayoutDoneAction {
     type: typeof APPLY_LAYOUT_DONE;
 }
 
+export interface FetchDiagnosticsAction {
+    type: typeof FETCH_DIAGNOSTICS;
+}
+
+export interface FetchDiagnosticsDoneAction {
+    type: typeof FETCH_DIAGNOSTICS_DONE;
+    payload: { report: VaultDiagnosticsReport };
+}
+
+export interface FetchDiagnosticsFailedAction {
+    type: typeof FETCH_DIAGNOSTICS_FAILED;
+    payload: { error: string };
+}
+
+export interface ReapplyBootstrapAction {
+    type: typeof REAPPLY_BOOTSTRAP;
+}
+
+export interface ReapplyBootstrapDoneAction {
+    type: typeof REAPPLY_BOOTSTRAP_DONE;
+}
+
+export interface ReinstallPluginsAction {
+    type: typeof REINSTALL_PLUGINS;
+}
+
+export interface ReinstallPluginsDoneAction {
+    type: typeof REINSTALL_PLUGINS_DONE;
+}
+
 export type ObsidianAction =
     | SetupObsidianAction
     | SetupObsidianDoneAction
     | BulkExportAction
     | BulkExportDoneAction
     | ApplyLayoutAction
-    | ApplyLayoutDoneAction;
+    | ApplyLayoutDoneAction
+    | FetchDiagnosticsAction
+    | FetchDiagnosticsDoneAction
+    | FetchDiagnosticsFailedAction
+    | ReapplyBootstrapAction
+    | ReapplyBootstrapDoneAction
+    | ReinstallPluginsAction
+    | ReinstallPluginsDoneAction;
 
 export const setupObsidian = (vaultPath?: string): SetupObsidianAction => ({
     type: SETUP_OBSIDIAN,
@@ -51,3 +100,19 @@ export const bulkExportDone = (): BulkExportDoneAction => ({type: BULK_EXPORT_DO
 
 export const applyLayout = (): ApplyLayoutAction => ({type: APPLY_LAYOUT});
 export const applyLayoutDone = (): ApplyLayoutDoneAction => ({type: APPLY_LAYOUT_DONE});
+
+export const fetchDiagnostics = (): FetchDiagnosticsAction => ({type: FETCH_DIAGNOSTICS});
+export const fetchDiagnosticsDone = (report: VaultDiagnosticsReport): FetchDiagnosticsDoneAction => ({
+    type: FETCH_DIAGNOSTICS_DONE,
+    payload: {report},
+});
+export const fetchDiagnosticsFailed = (error: string): FetchDiagnosticsFailedAction => ({
+    type: FETCH_DIAGNOSTICS_FAILED,
+    payload: {error},
+});
+
+export const reapplyBootstrap = (): ReapplyBootstrapAction => ({type: REAPPLY_BOOTSTRAP});
+export const reapplyBootstrapDone = (): ReapplyBootstrapDoneAction => ({type: REAPPLY_BOOTSTRAP_DONE});
+
+export const reinstallPlugins = (): ReinstallPluginsAction => ({type: REINSTALL_PLUGINS});
+export const reinstallPluginsDone = (): ReinstallPluginsDoneAction => ({type: REINSTALL_PLUGINS_DONE});

--- a/frontend/src/store/slices/obsidian/mutations.ts
+++ b/frontend/src/store/slices/obsidian/mutations.ts
@@ -1,3 +1,4 @@
+import type {VaultDiagnosticsReport} from "../../../api/ObsidianApi";
 import type {ObsidianState} from "./types";
 
 export const beginSetup = (state: ObsidianState): ObsidianState => ({
@@ -13,4 +14,36 @@ export const beginBulkExport = (state: ObsidianState): ObsidianState => ({
 export const beginApplyLayout = (state: ObsidianState): ObsidianState => ({
     ...state,
     isApplyingLayout: true,
+});
+
+export const beginDiagnosticsLoad = (state: ObsidianState): ObsidianState => ({
+    ...state,
+    isDiagnosticsLoading: true,
+    diagnosticsError: null,
+});
+
+export const setDiagnostics = (
+    state: ObsidianState,
+    report: VaultDiagnosticsReport,
+): ObsidianState => ({
+    ...state,
+    isDiagnosticsLoading: false,
+    diagnostics: report,
+    diagnosticsError: null,
+});
+
+export const setDiagnosticsError = (state: ObsidianState, error: string): ObsidianState => ({
+    ...state,
+    isDiagnosticsLoading: false,
+    diagnosticsError: error,
+});
+
+export const beginReapplyBootstrap = (state: ObsidianState): ObsidianState => ({
+    ...state,
+    isReapplyingBootstrap: true,
+});
+
+export const beginReinstallPlugins = (state: ObsidianState): ObsidianState => ({
+    ...state,
+    isReinstallingPlugins: true,
 });

--- a/frontend/src/store/slices/obsidian/reducer.ts
+++ b/frontend/src/store/slices/obsidian/reducer.ts
@@ -5,11 +5,27 @@ import {
     APPLY_LAYOUT_DONE,
     BULK_EXPORT,
     BULK_EXPORT_DONE,
+    FETCH_DIAGNOSTICS,
+    FETCH_DIAGNOSTICS_DONE,
+    FETCH_DIAGNOSTICS_FAILED,
     type ObsidianAction,
+    REAPPLY_BOOTSTRAP,
+    REAPPLY_BOOTSTRAP_DONE,
+    REINSTALL_PLUGINS,
+    REINSTALL_PLUGINS_DONE,
     SETUP_OBSIDIAN,
     SETUP_OBSIDIAN_DONE,
 } from "./actions";
-import {beginApplyLayout, beginBulkExport, beginSetup} from "./mutations";
+import {
+    beginApplyLayout,
+    beginBulkExport,
+    beginDiagnosticsLoad,
+    beginReapplyBootstrap,
+    beginReinstallPlugins,
+    beginSetup,
+    setDiagnostics,
+    setDiagnosticsError,
+} from "./mutations";
 import {initialObsidianState, type ObsidianState} from "./types";
 
 export const obsidianReducer: Reducer<ObsidianState> = (
@@ -32,6 +48,23 @@ export const obsidianReducer: Reducer<ObsidianState> = (
             return beginApplyLayout(state);
         case APPLY_LAYOUT_DONE:
             return {...state, isApplyingLayout: false};
+
+        case FETCH_DIAGNOSTICS:
+            return beginDiagnosticsLoad(state);
+        case FETCH_DIAGNOSTICS_DONE:
+            return setDiagnostics(state, typed.payload.report);
+        case FETCH_DIAGNOSTICS_FAILED:
+            return setDiagnosticsError(state, typed.payload.error);
+
+        case REAPPLY_BOOTSTRAP:
+            return beginReapplyBootstrap(state);
+        case REAPPLY_BOOTSTRAP_DONE:
+            return {...state, isReapplyingBootstrap: false};
+
+        case REINSTALL_PLUGINS:
+            return beginReinstallPlugins(state);
+        case REINSTALL_PLUGINS_DONE:
+            return {...state, isReinstallingPlugins: false};
 
         default:
             return state;

--- a/frontend/src/store/slices/obsidian/saga/bulkExportSaga.ts
+++ b/frontend/src/store/slices/obsidian/saga/bulkExportSaga.ts
@@ -1,9 +1,11 @@
+import axios from "axios";
 import {call, put, takeLatest} from "redux-saga/effects";
 import type {SagaIterator} from "redux-saga";
 
 import {apiFactory} from "../../../../api";
-import {notifyError, notifySuccess} from "../../notifications";
-import {BULK_EXPORT, bulkExportDone} from "../actions";
+import type {ObsidianBulkExportError} from "../../../../api/ObsidianApi";
+import {notifyError, notifyInfo, notifySuccess} from "../../notifications";
+import {BULK_EXPORT, bulkExportDone, fetchDiagnostics} from "../actions";
 import type {ObsidianBulkExportReport} from "../types";
 
 export function* bulkExportSaga(): SagaIterator {
@@ -13,20 +15,49 @@ export function* bulkExportSaga(): SagaIterator {
             obsidianApi,
             obsidianApi.bulkExport,
         ]);
-        yield put(notifySuccess({
-            messageKey: "obsidian.syncAllSuccess",
-            params: {count: report.exportedCount},
-        }));
+        if (report.exportedCount === 0 && report.skippedCount > 0) {
+            yield put(notifyInfo({
+                messageKey: "obsidian.syncAllUpToDate",
+                params: {count: report.skippedCount},
+            }));
+        } else {
+            yield put(notifySuccess({
+                messageKey: "obsidian.syncAllSuccess",
+                params: {count: report.exportedCount},
+            }));
+        }
     } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        yield put(notifyError({
-            messageKey: "errors.genericErrorWithMessage",
-            params: {message},
-        }));
+        const enriched = extractEnrichedError(error);
+        if (enriched) {
+            yield put(notifyError({
+                messageKey: `obsidian.emptyState.${enriched.error}`,
+                params: {hint: enriched.hint},
+            }));
+            yield put(fetchDiagnostics());
+        } else {
+            const message = error instanceof Error ? error.message : String(error);
+            yield put(notifyError({
+                messageKey: "errors.genericErrorWithMessage",
+                params: {message},
+            }));
+        }
     }
     yield put(bulkExportDone());
 }
 
 export function* watchBulkExport(): SagaIterator {
     yield takeLatest(BULK_EXPORT, bulkExportSaga);
+}
+
+function extractEnrichedError(error: unknown): ObsidianBulkExportError | null {
+    if (!axios.isAxiosError(error)) return null;
+    const body = error.response?.data;
+    if (!body || typeof body !== "object") return null;
+    const candidate = body as Partial<ObsidianBulkExportError>;
+    if (typeof candidate.error !== "string" || typeof candidate.hint !== "string") return null;
+    return {
+        error: candidate.error,
+        hint: candidate.hint,
+        actions: Array.isArray(candidate.actions) ? candidate.actions : [],
+    };
 }

--- a/frontend/src/store/slices/obsidian/saga/diagnosticsSaga.ts
+++ b/frontend/src/store/slices/obsidian/saga/diagnosticsSaga.ts
@@ -1,0 +1,25 @@
+import {call, put, takeLatest} from "redux-saga/effects";
+import type {SagaIterator} from "redux-saga";
+
+import {apiFactory} from "../../../../api";
+import type {VaultDiagnosticsReport} from "../../../../api/ObsidianApi";
+import {
+    FETCH_DIAGNOSTICS,
+    fetchDiagnosticsDone,
+    fetchDiagnosticsFailed,
+} from "../actions";
+
+export function* diagnosticsSaga(): SagaIterator {
+    const obsidianApi = apiFactory.createObsidianApi();
+    try {
+        const report: VaultDiagnosticsReport = yield call([obsidianApi, obsidianApi.diagnostics]);
+        yield put(fetchDiagnosticsDone(report));
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        yield put(fetchDiagnosticsFailed(message));
+    }
+}
+
+export function* watchFetchDiagnostics(): SagaIterator {
+    yield takeLatest(FETCH_DIAGNOSTICS, diagnosticsSaga);
+}

--- a/frontend/src/store/slices/obsidian/saga/index.ts
+++ b/frontend/src/store/slices/obsidian/saga/index.ts
@@ -3,12 +3,25 @@ import type {SagaIterator} from "redux-saga";
 
 import {watchApplyLayout} from "./applyLayoutSaga";
 import {watchBulkExport} from "./bulkExportSaga";
+import {watchFetchDiagnostics} from "./diagnosticsSaga";
+import {watchReapplyBootstrap} from "./reapplyBootstrapSaga";
+import {watchReinstallPlugins} from "./reinstallPluginsSaga";
 import {watchSetupObsidian} from "./setupObsidianSaga";
 
 export {applyLayoutSaga} from "./applyLayoutSaga";
 export {bulkExportSaga} from "./bulkExportSaga";
+export {diagnosticsSaga} from "./diagnosticsSaga";
+export {reapplyBootstrapSaga} from "./reapplyBootstrapSaga";
+export {reinstallPluginsSaga} from "./reinstallPluginsSaga";
 export {setupObsidianSaga} from "./setupObsidianSaga";
 
 export function* watchObsidianSagas(): SagaIterator {
-    yield all([fork(watchSetupObsidian), fork(watchBulkExport), fork(watchApplyLayout)]);
+    yield all([
+        fork(watchSetupObsidian),
+        fork(watchBulkExport),
+        fork(watchApplyLayout),
+        fork(watchFetchDiagnostics),
+        fork(watchReapplyBootstrap),
+        fork(watchReinstallPlugins),
+    ]);
 }

--- a/frontend/src/store/slices/obsidian/saga/reapplyBootstrapSaga.ts
+++ b/frontend/src/store/slices/obsidian/saga/reapplyBootstrapSaga.ts
@@ -1,0 +1,28 @@
+import {call, put, takeLatest} from "redux-saga/effects";
+import type {SagaIterator} from "redux-saga";
+
+import {apiFactory} from "../../../../api";
+import type {ObsidianReapplyResult} from "../../../../api/ObsidianApi";
+import {notifyError, notifySuccess} from "../../notifications";
+import {
+    REAPPLY_BOOTSTRAP,
+    fetchDiagnosticsDone,
+    reapplyBootstrapDone,
+} from "../actions";
+
+export function* reapplyBootstrapSaga(): SagaIterator {
+    const obsidianApi = apiFactory.createObsidianApi();
+    try {
+        const result: ObsidianReapplyResult = yield call([obsidianApi, obsidianApi.reapplyBootstrap]);
+        yield put(fetchDiagnosticsDone(result.report));
+        yield put(notifySuccess({messageKey: "obsidian.diagnostics.reapplyBootstrapSuccess"}));
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        yield put(notifyError({messageKey: "errors.genericErrorWithMessage", params: {message}}));
+    }
+    yield put(reapplyBootstrapDone());
+}
+
+export function* watchReapplyBootstrap(): SagaIterator {
+    yield takeLatest(REAPPLY_BOOTSTRAP, reapplyBootstrapSaga);
+}

--- a/frontend/src/store/slices/obsidian/saga/reinstallPluginsSaga.ts
+++ b/frontend/src/store/slices/obsidian/saga/reinstallPluginsSaga.ts
@@ -1,0 +1,32 @@
+import {call, put, takeLatest} from "redux-saga/effects";
+import type {SagaIterator} from "redux-saga";
+
+import {apiFactory} from "../../../../api";
+import type {ObsidianReinstallResult} from "../../../../api/ObsidianApi";
+import {notifyError, notifySuccess} from "../../notifications";
+import {
+    REINSTALL_PLUGINS,
+    fetchDiagnosticsDone,
+    reinstallPluginsDone,
+} from "../actions";
+
+export function* reinstallPluginsSaga(): SagaIterator {
+    const obsidianApi = apiFactory.createObsidianApi();
+    try {
+        const result: ObsidianReinstallResult = yield call([obsidianApi, obsidianApi.reinstallPlugins]);
+        yield put(fetchDiagnosticsDone(result.report));
+        const installed = result.plugins.filter((p) => p.status === "Installed" || p.status === "AlreadyInstalled").length;
+        yield put(notifySuccess({
+            messageKey: "obsidian.diagnostics.reinstallPluginsSuccess",
+            params: {count: installed},
+        }));
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        yield put(notifyError({messageKey: "errors.genericErrorWithMessage", params: {message}}));
+    }
+    yield put(reinstallPluginsDone());
+}
+
+export function* watchReinstallPlugins(): SagaIterator {
+    yield takeLatest(REINSTALL_PLUGINS, reinstallPluginsSaga);
+}

--- a/frontend/src/store/slices/obsidian/selectors.ts
+++ b/frontend/src/store/slices/obsidian/selectors.ts
@@ -16,3 +16,23 @@ export const selectObsidianIsSetupInProgress = createSelector(
     selectObsidianState,
     (slice) => slice.isSetupInProgress,
 );
+export const selectObsidianDiagnostics = createSelector(
+    selectObsidianState,
+    (slice) => slice.diagnostics,
+);
+export const selectObsidianDiagnosticsLoading = createSelector(
+    selectObsidianState,
+    (slice) => slice.isDiagnosticsLoading,
+);
+export const selectObsidianDiagnosticsError = createSelector(
+    selectObsidianState,
+    (slice) => slice.diagnosticsError,
+);
+export const selectObsidianIsReapplyingBootstrap = createSelector(
+    selectObsidianState,
+    (slice) => slice.isReapplyingBootstrap,
+);
+export const selectObsidianIsReinstallingPlugins = createSelector(
+    selectObsidianState,
+    (slice) => slice.isReinstallingPlugins,
+);

--- a/frontend/src/store/slices/obsidian/types.ts
+++ b/frontend/src/store/slices/obsidian/types.ts
@@ -1,3 +1,5 @@
+import type {VaultDiagnosticsReport} from "../../../api/ObsidianApi";
+
 export interface ObsidianSetupReport {
     readonly createdPaths: readonly string[];
 }
@@ -9,16 +11,27 @@ export interface ObsidianApplyLayoutReport {
 
 export interface ObsidianBulkExportReport {
     readonly exportedCount: number;
+    readonly skippedCount: number;
 }
 
 export interface ObsidianState {
     readonly isSetupInProgress: boolean;
     readonly isBulkExporting: boolean;
     readonly isApplyingLayout: boolean;
+    readonly isDiagnosticsLoading: boolean;
+    readonly isReapplyingBootstrap: boolean;
+    readonly isReinstallingPlugins: boolean;
+    readonly diagnostics: VaultDiagnosticsReport | null;
+    readonly diagnosticsError: string | null;
 }
 
 export const initialObsidianState: ObsidianState = {
     isSetupInProgress: false,
     isBulkExporting: false,
     isApplyingLayout: false,
+    isDiagnosticsLoading: false,
+    isReapplyingBootstrap: false,
+    isReinstallingPlugins: false,
+    diagnostics: null,
+    diagnosticsError: null,
 };


### PR DESCRIPTION
## Scope (MR 3/3, Draft)

Frontend layer for ADR-019. Stacks on #48 (skeleton) + #49 (backend) which are already merged into \`main\`.

### UI (`features/Obsidian/Obsidian.tsx`)
- New **Diagnostics card** — chip grid colored by severity from `GET /api/obsidian/diagnostics`: vault / each pinned plugin / Templater settings / bootstrap drift / REST API / LM Studio.
- Actions: Refresh · Reapply templates · Reinstall plugins.
- **Empty-state banner** when vault path is unset — replaces the silent "exported 0" UX.

### Store (`store/slices/obsidian/*`)
- Actions + reducer + selectors for diagnostics / reapply / reinstall.
- Sagas: `diagnosticsSaga`, `reapplyBootstrapSaga`, `reinstallPluginsSaga`.
- `bulkExportSaga`: on 4xx with `{error, hint, actions}` → localized toast keyed by error code + fresh diagnostics fetch. On 200 with `exportedCount=0 && skippedCount>0` → "up to date" info toast.

### API client
- Typed `diagnostics()` / `reapplyBootstrap()` / `reinstallPlugins()` on `ObsidianApi`.
- Full `VaultDiagnosticsReport` + `ObsidianBulkExportError` readonly types.

### i18n (ru + en)
- `obsidian.diagnostics.*`, `obsidian.emptyState.*`, `obsidian.syncAllUpToDate`.

## Status
- `cd frontend && npm run typecheck` — green.
- `cd frontend && npm run build` — green.
- 4 existing `Obsidian.test.tsx` + 4 `bulkExportSaga.test.ts` tests preserved (minor type-fix: `ObsidianBulkExportResult` gained `skippedCount` + `failures`).

## Out of scope
- Full 5-step wizard stepper (vault pick → plugin install → user-enable poll → REST-token capture → bootstrap install). Scoped as a follow-up once diagnostics view has been validated on the dev box.
- `ProcessedNoteSaved` publisher + `ObsidianDomainEventHandler` background export — backend follow-up.

## D4 smoke (macOS — defer to shuka)
ADR-019 §9 D4 smoke requires Obsidian app + macOS. Please run after MR3 land.