### PR TITLE
refactor(queue): dispatch actions via jobs slice instead of direct graphqlClient calls

### DIFF
--- a/frontend/src/features/Queue/Queue.tsx
+++ b/frontend/src/features/Queue/Queue.tsx
@@ -1,22 +1,16 @@
-import { FC, useCallback, useEffect, useMemo, useState } from "react";
+import { FC, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ListChecks, X } from "lucide-react";
-import { toast } from "react-toastify";
-import { print } from "graphql";
+import { useDispatch, useSelector } from "react-redux";
+import type { Action, Dispatch } from "redux";
 
 import Badge, { BadgeTone } from "../../components/Badge";
 import Button from "../../components/Button";
 import Card from "../../components/Card";
 import EmptyState from "../../components/EmptyState";
 import ProgressBar from "../../components/ProgressBar";
-import { graphqlClient, getGraphqlWsClient } from "../../api/graphqlClient";
-import {
-  MutationCancelJobDocument,
-  QueryJobsDocument,
-  SubscriptionJobProgressDocument,
-} from "../../api/gql/graphql";
-import type { SubscriptionJobProgressSubscription } from "../../api/gql/graphql";
 import { ProcessingJob } from "../../domain/ProcessingJob";
+import { cancelJob as cancelJobAction, selectAllJobs } from "../../store/slices/jobs";
 import { JobHeader, JobMeta, JobRow, PageRoot, PageTitle, ResumeCopy } from "./Queue.style";
 
 const TERMINAL: ProcessingJob["status"][] = ["Done", "Failed", "Cancelled"];
@@ -39,46 +33,9 @@ const formatHHMM = (iso: string): string => {
 
 const Queue: FC = () => {
   const { t } = useTranslation();
-  const [jobs, setJobs] = useState<ProcessingJob[]>([]);
+  const dispatch = useDispatch<Dispatch<Action>>();
+  const jobs = useSelector(selectAllJobs);
   const [cancellingIds, setCancellingIds] = useState<Set<string>>(() => new Set());
-
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const data = await graphqlClient.request(QueryJobsDocument, { first: 200 });
-        if (!cancelled) {
-          setJobs((data.jobs?.nodes ?? []) as unknown as ProcessingJob[]);
-        }
-      } catch {}
-    })();
-
-    const wsClient = getGraphqlWsClient();
-    const unsubscribe = wsClient.subscribe<SubscriptionJobProgressSubscription>(
-      { query: print(SubscriptionJobProgressDocument) },
-      {
-        next: (value) => {
-          if (!value.data) return;
-          const job = value.data.jobProgress as unknown as ProcessingJob;
-          setJobs((prev) => {
-            const idx = prev.findIndex((j) => j.id === job.id);
-            if (idx === -1) return [job, ...prev];
-            const copy = prev.slice();
-            copy[idx] = { ...copy[idx], ...job };
-            return copy;
-          });
-        },
-        error: () => {},
-        complete: () => {},
-      }
-    );
-
-    return () => {
-      cancelled = true;
-      unsubscribe();
-      void wsClient.dispose();
-    };
-  }, []);
 
   const sorted = useMemo(
     () =>
@@ -89,7 +46,7 @@ const Queue: FC = () => {
   );
 
   const handleCancel = useCallback(
-    async (job: ProcessingJob) => {
+    (job: ProcessingJob) => {
       const isRunning = !TERMINAL.includes(job.status) && job.status !== "Queued";
       if (isRunning) {
         const ok = window.confirm(t("queue.cancelConfirmRunning"));
@@ -100,20 +57,16 @@ const Queue: FC = () => {
         next.add(job.id);
         return next;
       });
-      try {
-        await graphqlClient.request(MutationCancelJobDocument, { id: job.id });
-        setJobs((prev) => prev.filter((j) => j.id !== job.id));
-      } catch (err) {
-        toast.error(err instanceof Error ? err.message : String(err));
-      } finally {
+      dispatch(cancelJobAction(job.id));
+      void Promise.resolve().then(() => {
         setCancellingIds((prev) => {
           const next = new Set(prev);
           next.delete(job.id);
           return next;
         });
-      }
+      });
     },
-    [t]
+    [t, dispatch]
   );
 
   return (
@@ -151,7 +104,7 @@ const Queue: FC = () => {
                       leftIcon={<X size={14} />}
                       isLoading={isCancelling}
                       disabled={isCancelling}
-                      onClick={() => void handleCancel(job)}
+                      onClick={() => handleCancel(job)}
                     >
                       {t("queue.cancel")}
                     </Button>

--- a/frontend/src/features/Queue/__tests__/Queue.test.tsx
+++ b/frontend/src/features/Queue/__tests__/Queue.test.tsx
@@ -1,35 +1,12 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { ThemeProvider } from "styled-components";
 
 import Queue from "../Queue";
 import { lightTheme } from "../../../styles/theme";
 import { ProcessingJob } from "../../../domain/ProcessingJob";
+import { cancelJob as cancelJobAction, jobUpdated } from "../../../store/slices/jobs";
+import { renderWithStore, mockJobsState, jobsById } from "../../../testUtils";
 import "../../../i18n";
-
-type JobSink = {
-  next: (value: { data: { jobProgress: ProcessingJob } }) => void;
-  error: (err: unknown) => void;
-  complete: () => void;
-};
-
-let activeJobSink: JobSink | null = null;
-// eslint-disable-next-line no-var -- jest.mock factories run before `let` is initialised; `var` keeps hoisting semantics
-var mockRequest: jest.Mock;
-
-jest.mock("../../../api/graphqlClient", () => {
-  mockRequest = jest.fn();
-  return {
-    graphqlClient: { request: mockRequest },
-    getGraphqlWsClient: jest.fn(() => ({
-      subscribe: jest.fn((_query: unknown, sink: JobSink) => {
-        activeJobSink = sink;
-        return () => {};
-      }),
-      dispose: jest.fn(),
-    })),
-  };
-});
 
 jest.mock("react-toastify", () => ({
   toast: {
@@ -57,58 +34,39 @@ const buildJob = (patch: Partial<ProcessingJob>): ProcessingJob => ({
   checkpointAt: patch.checkpointAt,
 });
 
-const renderQueue = () =>
-  render(
-    <ThemeProvider theme={lightTheme}>
-      <Queue />
-    </ThemeProvider>
-  );
-
 beforeEach(() => {
   jest.clearAllMocks();
-  activeJobSink = null;
 });
 
 describe("Queue — cancel UI (BC-015 / Bug 19)", () => {
-  it("Queue_CancelQueued_FiresDelete_RemovesRow", async () => {
+  it("Queue_CancelQueued_DispatchesCancelJob", async () => {
     const job = buildJob({ id: "job-q", status: "Queued" });
-    mockRequest
-      .mockResolvedValueOnce({ jobs: { nodes: [job], pageInfo: { hasNextPage: false } } })
-      .mockResolvedValueOnce({ cancelJob: { errors: [] } });
-
-    renderQueue();
+    const { getActions } = renderWithStore(<Queue />, {
+      preloadedState: mockJobsState({ byId: jobsById([job]) }),
+      theme: lightTheme,
+    });
 
     const cancelBtn = await screen.findByTestId(`queue-cancel-${job.id}`);
     expect(cancelBtn).toBeEnabled();
     await userEvent.click(cancelBtn);
 
-    await waitFor(() =>
-      expect(mockRequest).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ id: job.id })
-      )
-    );
+    expect(getActions()).toContainEqual(cancelJobAction(job.id));
   });
 
-  it("Queue_CancelRunning_Confirmation_CallsDelete", async () => {
+  it("Queue_CancelRunning_Confirmation_DispatchesCancel", async () => {
     const job = buildJob({ id: "job-r", status: "Transcribing", progress: 30 });
-    mockRequest
-      .mockResolvedValueOnce({ jobs: { nodes: [job], pageInfo: { hasNextPage: false } } })
-      .mockResolvedValueOnce({ cancelJob: { errors: [] } });
-
     const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
 
-    renderQueue();
+    const { getActions } = renderWithStore(<Queue />, {
+      preloadedState: mockJobsState({ byId: jobsById([job]) }),
+      theme: lightTheme,
+    });
+
     const cancelBtn = await screen.findByTestId(`queue-cancel-${job.id}`);
     await userEvent.click(cancelBtn);
 
-    await waitFor(() =>
-      expect(mockRequest).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ id: job.id })
-      )
-    );
     expect(confirmSpy).toHaveBeenCalled();
+    expect(getActions()).toContainEqual(cancelJobAction(job.id));
 
     confirmSpy.mockRestore();
   });
@@ -116,28 +74,26 @@ describe("Queue — cancel UI (BC-015 / Bug 19)", () => {
   it("Queue_CancelHidden_OnDoneAndFailed", async () => {
     const done = buildJob({ id: "job-done-001", status: "Done", progress: 100 });
     const failed = buildJob({ id: "job-fail-001", status: "Failed" });
-    mockRequest.mockResolvedValue({
-      jobs: { nodes: [done, failed], pageInfo: { hasNextPage: false } },
-    });
 
-    renderQueue();
+    renderWithStore(<Queue />, {
+      preloadedState: mockJobsState({ byId: jobsById([done, failed]) }),
+      theme: lightTheme,
+    });
 
     await waitFor(() => expect(screen.getAllByText(/Готово|Done/).length).toBeGreaterThan(0));
     expect(screen.queryByTestId(`queue-cancel-${done.id}`)).not.toBeInTheDocument();
     expect(screen.queryByTestId(`queue-cancel-${failed.id}`)).not.toBeInTheDocument();
   });
 
-  it("Queue_SseReconnect_OnConnectionLoss — subscription updates job list", async () => {
+  it("Queue_SubscriptionPush_UpdatesList", async () => {
     const job = buildJob({ id: "job-live", status: "Transcribing", progress: 10 });
-    mockRequest.mockResolvedValue({ jobs: { nodes: [], pageInfo: { hasNextPage: false } } });
 
-    renderQueue();
-
-    await waitFor(() => expect(activeJobSink).not.toBeNull());
-
-    act(() => {
-      activeJobSink!.next({ data: { jobProgress: job } });
+    const { store } = renderWithStore(<Queue />, {
+      preloadedState: mockJobsState({ byId: {} }),
+      theme: lightTheme,
     });
+
+    store.dispatch(jobUpdated(job) as never);
 
     await waitFor(() => expect(screen.getByTestId(`queue-cancel-${job.id}`)).toBeInTheDocument());
   });
@@ -150,37 +106,16 @@ describe("Queue — ADR-015 cancelled terminal state", () => {
       status: "Cancelled",
       finishedAt: new Date("2026-04-18T09:00:00Z").toISOString(),
     });
-    mockRequest.mockResolvedValue({ jobs: { nodes: [job], pageInfo: { hasNextPage: false } } });
 
-    renderQueue();
+    renderWithStore(<Queue />, {
+      preloadedState: mockJobsState({ byId: jobsById([job]) }),
+      theme: lightTheme,
+    });
 
     await waitFor(() =>
       expect(screen.getAllByText(/Отменено|Cancelled/).length).toBeGreaterThan(0)
     );
     expect(screen.queryByTestId(`queue-cancel-${job.id}`)).not.toBeInTheDocument();
-  });
-
-  it("Queue_CancelOnSuccess_DoesNotShowToastError", async () => {
-    const job = buildJob({ id: "job-cancel-ok-001", status: "Queued" });
-    mockRequest
-      .mockResolvedValueOnce({ jobs: { nodes: [job], pageInfo: { hasNextPage: false } } })
-      .mockResolvedValueOnce({ cancelJob: { errors: [] } });
-
-    const { toast } = jest.requireMock("react-toastify") as {
-      toast: { error: jest.Mock };
-    };
-
-    renderQueue();
-    const cancelBtn = await screen.findByTestId(`queue-cancel-${job.id}`);
-    await userEvent.click(cancelBtn);
-
-    await waitFor(() =>
-      expect(mockRequest).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ id: job.id })
-      )
-    );
-    expect(toast.error).not.toHaveBeenCalled();
   });
 });
 
@@ -193,9 +128,11 @@ describe("Queue — resume copy (BC-017 / Bug 21)", () => {
       resumedFromCheckpoint: true,
       checkpointAt: "2026-04-17T07:23:00Z",
     });
-    mockRequest.mockResolvedValue({ jobs: { nodes: [job], pageInfo: { hasNextPage: false } } });
 
-    renderQueue();
+    renderWithStore(<Queue />, {
+      preloadedState: mockJobsState({ byId: jobsById([job]) }),
+      theme: lightTheme,
+    });
 
     expect(await screen.findByText(/Resumed from|Возобновлено с/)).toBeInTheDocument();
   });
@@ -206,9 +143,11 @@ describe("Queue — resume copy (BC-017 / Bug 21)", () => {
       status: "Transcribing",
       progress: 20,
     });
-    mockRequest.mockResolvedValue({ jobs: { nodes: [job], pageInfo: { hasNextPage: false } } });
 
-    renderQueue();
+    renderWithStore(<Queue />, {
+      preloadedState: mockJobsState({ byId: jobsById([job]) }),
+      theme: lightTheme,
+    });
 
     await waitFor(() =>
       expect(screen.getAllByText(/Транскрибация|Transcribing/).length).toBeGreaterThan(0)

--- a/frontend/src/store/slices/jobs/__tests__/saga.test.ts
+++ b/frontend/src/store/slices/jobs/__tests__/saga.test.ts
@@ -75,10 +75,12 @@ beforeEach(() => {
 });
 
 describe("subscribeJobsSaga", () => {
-  it("seeds from activeJobs and emits JOBS_SEEDED", async () => {
+  it("seeds from QueryJobs(first:200) and emits JOBS_SEEDED", async () => {
     const wsStub = makeWsClientStub();
     mockedGetWsClient.mockReturnValue(wsStub);
-    mockedRequest.mockResolvedValueOnce({ activeJobs: [gqlJobA] });
+    mockedRequest.mockResolvedValueOnce({
+      jobs: { nodes: [gqlJobA], pageInfo: { hasNextPage: false, endCursor: null } },
+    });
 
     const result = await expectSaga(subscribeJobsSaga)
       .withReducer(jobsReducer)
@@ -103,7 +105,7 @@ describe("subscribeJobsSaga", () => {
     expect(result.storeState.byId.a.id).toBe("a");
   });
 
-  it("emits JOBS_SEED_FAILED when activeJobs throws but still opens the stream", async () => {
+  it("emits JOBS_SEED_FAILED when QueryJobs throws but still opens the stream", async () => {
     const wsStub = makeWsClientStub();
     mockedGetWsClient.mockReturnValue(wsStub);
     mockedRequest.mockRejectedValueOnce(new Error("boom"));
@@ -127,7 +129,9 @@ describe("subscribeJobsSaga", () => {
     });
     const wsStub = { subscribe, dispose };
     mockedGetWsClient.mockReturnValue(wsStub);
-    mockedRequest.mockResolvedValueOnce({ activeJobs: [] });
+    mockedRequest.mockResolvedValueOnce({
+      jobs: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+    });
 
     const incoming = makeJob({
       id: "x",

--- a/frontend/src/store/slices/jobs/saga/subscribeJobsSaga.ts
+++ b/frontend/src/store/slices/jobs/saga/subscribeJobsSaga.ts
@@ -3,13 +3,10 @@ import type { SagaIterator } from "redux-saga";
 import type { Task, EventChannel } from "redux-saga";
 
 import type {
-  QueryActiveJobsQuery,
+  QueryJobsQuery,
   SubscriptionJobProgressSubscription,
 } from "../../../../api/gql/graphql";
-import {
-  QueryActiveJobsDocument,
-  SubscriptionJobProgressDocument,
-} from "../../../../api/gql/graphql";
+import { QueryJobsDocument, SubscriptionJobProgressDocument } from "../../../../api/gql/graphql";
 import { gqlRequest, gqlSubscriptionChannel } from "../../../saga/graphql";
 import { mapGqlJob } from "../jobMapper";
 import {
@@ -39,8 +36,8 @@ function* consumeChannel(channel: EventChannel<SubscriptionJobProgressSubscripti
 
 export function* subscribeJobsSaga(): SagaIterator {
   try {
-    const result = (yield* gqlRequest(QueryActiveJobsDocument, {})) as QueryActiveJobsQuery;
-    const jobs = (result.activeJobs ?? []).map(mapGqlJob);
+    const result = (yield* gqlRequest(QueryJobsDocument, { first: 200 })) as QueryJobsQuery;
+    const jobs = (result.jobs?.nodes ?? []).map(mapGqlJob);
     yield put(jobsSeeded(jobs));
   } catch (error) {
     yield put(jobsSeedFailed(error instanceof Error ? error.message : String(error)));

--- a/frontend/src/testUtils/index.ts
+++ b/frontend/src/testUtils/index.ts
@@ -4,3 +4,4 @@ export { renderWithRouter } from "./renderWithRouter";
 export type { RenderWithRouterOptions } from "./renderWithRouter";
 export { createMockApi } from "./mockApi";
 export type { MockApiBundle } from "./mockApi";
+export { mockJobsState, jobsById } from "./mockState";

--- a/frontend/src/testUtils/mockState.ts
+++ b/frontend/src/testUtils/mockState.ts
@@ -1,0 +1,10 @@
+import type { ProcessingJob } from "../domain/ProcessingJob";
+import type { GlobalState } from "../store/rootReducer";
+import { initialJobsState, type JobsState } from "../store/slices/jobs";
+
+export const jobsById = (jobs: readonly ProcessingJob[]): Record<string, ProcessingJob> =>
+  Object.fromEntries(jobs.map((job) => [job.id, job]));
+
+export const mockJobsState = (patch: Partial<JobsState> = {}): Pick<GlobalState, "jobs"> => ({
+  jobs: { ...initialJobsState, ...patch },
+});

--- a/frontend/src/testUtils/renderWithStore.tsx
+++ b/frontend/src/testUtils/renderWithStore.tsx
@@ -1,7 +1,8 @@
 import type { ReactElement, ReactNode } from "react";
 import { render, type RenderOptions, type RenderResult } from "@testing-library/react";
 import { Provider } from "react-redux";
-import { applyMiddleware, createStore, type Store } from "redux";
+import { applyMiddleware, createStore, type Middleware, type Store } from "redux";
+import type { AnyAction } from "redux";
 import type { SagaIterator } from "redux-saga";
 import createSagaMiddleware, { type SagaMiddleware } from "redux-saga";
 import { all, fork } from "redux-saga/effects";
@@ -22,17 +23,26 @@ export interface RenderWithStoreOptions {
 export interface RenderWithStoreResult extends RenderResult {
   readonly store: Store<GlobalState>;
   readonly sagaMiddleware: SagaMiddleware;
+  readonly recordedActions: readonly AnyAction[];
+  readonly getActions: () => AnyAction[];
 }
 
 export const renderWithStore = (
   ui: ReactElement,
   options: RenderWithStoreOptions = {}
 ): RenderWithStoreResult => {
+  const recorded: AnyAction[] = [];
+
+  const recorderMiddleware: Middleware = () => (next) => (action) => {
+    recorded.push(action as AnyAction);
+    return next(action);
+  };
+
   const sagaMiddleware = createSagaMiddleware();
   const store = createStore(
     rootReducer,
     options.preloadedState as GlobalState | undefined,
-    applyMiddleware(sagaMiddleware)
+    applyMiddleware(recorderMiddleware, sagaMiddleware)
   );
   if (options.sagas && options.sagas.length > 0) {
     const sagas = options.sagas;
@@ -52,5 +62,11 @@ export const renderWithStore = (
   );
 
   const result = render(ui, { wrapper: Wrapper, ...options.renderOptions });
-  return { ...result, store, sagaMiddleware };
+  return {
+    ...result,
+    store,
+    sagaMiddleware,
+    recordedActions: recorded,
+    getActions: () => recorded,
+  };
 };


### PR DESCRIPTION
Pilot for #120 — Queue migrated off direct `graphqlClient`.

## what
- `Queue.tsx` reads `selectAllJobs`, dispatches `cancelJob(id)`; no transport imports.
- `subscribeJobsSaga` switches to `QueryJobs(first:200)` to preserve recent-incl-terminal UX.
- `testUtils/mockState.ts` is the entry point for component-level store seeding.
- `renderWithStore` now records dispatched actions for action-level assertions.

## test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx jest src/features/Queue src/store/slices/jobs src/testUtils`
- [x] `bash scripts/agent-gate.sh frontend`

Refs #120.