### PR TITLE
refactor(home): HomeList dispatches actions instead of calling graphqlClient directly

### DIFF
--- a/frontend/src/features/Home/HomeList.tsx
+++ b/frontend/src/features/Home/HomeList.tsx
@@ -1,29 +1,32 @@
-import { FC, useEffect, useMemo, useState } from "react";
+import { FC, useEffect, useMemo, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { FileText, Mic, Trash2, X } from "lucide-react";
 import { toast } from "react-toastify";
-import { print } from "graphql";
+import { useDispatch, useSelector } from "react-redux";
+import type { Action, Dispatch } from "redux";
 
 import Badge, { BadgeTone } from "../../components/Badge";
 import Button from "../../components/Button";
 import Card from "../../components/Card";
 import EmptyState from "../../components/EmptyState";
 import ProgressBar from "../../components/ProgressBar";
-import { graphqlClient, getGraphqlWsClient } from "../../api/graphqlClient";
-import {
-  MutationCancelJobDocument,
-  MutationDeleteRecordingDocument,
-  QueryJobsDocument,
-  QueryRecordingsDocument,
-  QueryRecordingWithNotesDocument,
-  SubscriptionJobProgressDocument,
-} from "../../api/gql/graphql";
-import type { SubscriptionJobProgressSubscription } from "../../api/gql/graphql";
 import { RECORDINGS_CHANGED_EVENT } from "../../constants/events";
 import { noteRoute } from "../../constants/routes";
 import type { ProcessingJob } from "../../domain/ProcessingJob";
 import type { Recording } from "../../domain/Recording";
+import {
+  deleteRecording as deleteRecordingAction,
+  loadRecordings,
+  selectAllRecordings,
+  selectDeletingRecordingIds,
+} from "../../store/slices/recording";
+import { cancelJob as cancelJobAction, selectAllJobs } from "../../store/slices/jobs";
+import {
+  clearOpenNoteResolution,
+  openNoteRequested,
+  selectAllOpenNoteResolutions,
+} from "../../store/slices/ui";
 import {
   HomeListHeader,
   HomeListRoot,
@@ -48,65 +51,57 @@ const toneFor = (status: ProcessingJob["status"] | null): BadgeTone => {
 const HomeList: FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const [recordings, setRecordings] = useState<Recording[]>([]);
-  const [jobs, setJobs] = useState<ProcessingJob[]>([]);
-  const [openingNoteIds, setOpeningNoteIds] = useState<Set<string>>(() => new Set());
-  const [cancellingJobIds, setCancellingJobIds] = useState<Set<string>>(() => new Set());
-  const [deletingRecordingIds, setDeletingRecordingIds] = useState<Set<string>>(() => new Set());
+  const dispatch = useDispatch<Dispatch<Action>>();
+
+  const recordings = useSelector(selectAllRecordings);
+  const jobs = useSelector(selectAllJobs);
+  const deletingIds = useSelector(selectDeletingRecordingIds);
+  const openNoteResolutions = useSelector(selectAllOpenNoteResolutions);
+
+  const prevDeletingIdsRef = useRef<Record<string, true>>({});
 
   useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const [recData, jobData] = await Promise.all([
-          graphqlClient.request(QueryRecordingsDocument, { first: 200 }),
-          graphqlClient.request(QueryJobsDocument, { first: 200 }),
-        ]);
-        if (!cancelled) {
-          setRecordings((recData.recordings?.nodes ?? []) as unknown as Recording[]);
-          setJobs((jobData.jobs?.nodes ?? []) as unknown as ProcessingJob[]);
-        }
-      } catch {}
-    })();
-
-    const wsClient = getGraphqlWsClient();
-    const unsubscribe = wsClient.subscribe<SubscriptionJobProgressSubscription>(
-      { query: print(SubscriptionJobProgressDocument) },
-      {
-        next: (value) => {
-          if (!value.data) return;
-          const job = value.data.jobProgress as unknown as ProcessingJob;
-          setJobs((prev) => {
-            const idx = prev.findIndex((j) => j.id === job.id);
-            if (idx === -1) return [job, ...prev];
-            const next = prev.slice();
-            next[idx] = { ...next[idx], ...job };
-            return next;
-          });
-        },
-        error: () => {},
-        complete: () => {},
-      }
-    );
-
-    return () => {
-      cancelled = true;
-      unsubscribe();
-      void wsClient.dispose();
-    };
-  }, []);
+    dispatch(loadRecordings() as never);
+  }, [dispatch]);
 
   useEffect(() => {
     if (typeof window === "undefined") return undefined;
     const handler = (): void => {
-      void graphqlClient
-        .request(QueryRecordingsDocument, { first: 200 })
-        .then((data) => setRecordings((data.recordings?.nodes ?? []) as unknown as Recording[]))
-        .catch(() => {});
+      dispatch(loadRecordings() as never);
     };
     window.addEventListener(RECORDINGS_CHANGED_EVENT, handler);
     return () => window.removeEventListener(RECORDINGS_CHANGED_EVENT, handler);
-  }, []);
+  }, [dispatch]);
+
+  useEffect(() => {
+    for (const [recordingId, resolution] of Object.entries(openNoteResolutions)) {
+      if (resolution.status === "pending") continue;
+
+      if (resolution.status === "resolved") {
+        if (resolution.firstNoteId !== null) {
+          navigate(noteRoute(resolution.firstNoteId));
+        } else {
+          toast.info(t("home.noNoteYet"));
+        }
+      } else {
+        toast.error(resolution.error);
+      }
+
+      dispatch(clearOpenNoteResolution(recordingId) as never);
+    }
+  }, [openNoteResolutions, navigate, dispatch, t]);
+
+  useEffect(() => {
+    const prevIds = prevDeletingIdsRef.current;
+    const deletedIds = Object.keys(prevIds).filter((id) => !(id in deletingIds));
+    const recordingsById = Object.fromEntries(recordings.map((r) => [r.id, r]));
+    for (const id of deletedIds) {
+      if (!(id in recordingsById)) {
+        toast.success(t("home.deleted"));
+      }
+    }
+    prevDeletingIdsRef.current = deletingIds;
+  }, [deletingIds, recordings, t]);
 
   const latestJobByRecording = useMemo(() => {
     const map = new Map<string, ProcessingJob>();
@@ -124,67 +119,23 @@ const HomeList: FC = () => {
     [recordings]
   );
 
-  const openNote = async (recordingId: string): Promise<void> => {
-    if (openingNoteIds.has(recordingId)) return;
-    setOpeningNoteIds((prev) => new Set(prev).add(recordingId));
-    try {
-      const data = await graphqlClient.request(QueryRecordingWithNotesDocument, {
-        id: recordingId,
-      });
-      const notes = data.recording?.notes ?? [];
-      if (notes.length === 0) {
-        toast.info(t("home.noNoteYet"));
-        return;
-      }
-      navigate(noteRoute(notes[0]!.id));
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err));
-    } finally {
-      setOpeningNoteIds((prev) => {
-        const next = new Set(prev);
-        next.delete(recordingId);
-        return next;
-      });
-    }
+  const openNote = (recordingId: string): void => {
+    if (openNoteResolutions[recordingId]?.status === "pending") return;
+    dispatch(openNoteRequested(recordingId) as never);
   };
 
-  const deleteRecording = async (rec: Recording): Promise<void> => {
+  const deleteRecording = (rec: Recording): void => {
     const confirmed = window.confirm(t("home.deleteConfirm", { name: rec.fileName }));
     if (!confirmed) return;
-    setDeletingRecordingIds((prev) => new Set(prev).add(rec.id));
-    try {
-      await graphqlClient.request(MutationDeleteRecordingDocument, { id: rec.id });
-      setRecordings((prev) => prev.filter((r) => r.id !== rec.id));
-      setJobs((prev) => prev.filter((j) => j.recordingId !== rec.id));
-      toast.success(t("home.deleted"));
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err));
-    } finally {
-      setDeletingRecordingIds((prev) => {
-        const next = new Set(prev);
-        next.delete(rec.id);
-        return next;
-      });
-    }
+    dispatch(deleteRecordingAction(rec.id) as never);
   };
 
-  const cancelJob = async (job: ProcessingJob): Promise<void> => {
+  const cancelJob = (job: ProcessingJob): void => {
     if (!TERMINAL.includes(job.status) && job.status !== "Queued") {
       const ok = window.confirm(t("queue.cancelConfirmRunning"));
       if (!ok) return;
     }
-    setCancellingJobIds((prev) => new Set(prev).add(job.id));
-    try {
-      await graphqlClient.request(MutationCancelJobDocument, { id: job.id });
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err));
-    } finally {
-      setCancellingJobIds((prev) => {
-        const next = new Set(prev);
-        next.delete(job.id);
-        return next;
-      });
-    }
+    dispatch(cancelJobAction(job.id) as never);
   };
 
   return (
@@ -201,9 +152,8 @@ const HomeList: FC = () => {
             const progress = job?.progress ?? (isDone ? 100 : 0);
             const indeterminate = job !== null && !isTerminal && progress === 0;
             const statusText = job ? t(`queue.status.${job.status}` as const) : t("home.waiting");
-            const isOpening = openingNoteIds.has(rec.id);
-            const isCancelling = job !== null && cancellingJobIds.has(job.id);
-            const isDeleting = deletingRecordingIds.has(rec.id);
+            const isOpening = openNoteResolutions[rec.id]?.status === "pending";
+            const isDeleting = rec.id in deletingIds;
             return (
               <Card key={rec.id} data-testid={`home-row-${rec.id}`}>
                 <RowTop>
@@ -224,7 +174,7 @@ const HomeList: FC = () => {
                         isLoading={isOpening}
                         disabled={isOpening}
                         data-testid={`home-open-note-${rec.id}`}
-                        onClick={() => void openNote(rec.id)}
+                        onClick={() => openNote(rec.id)}
                       >
                         {t("home.openNote")}
                       </Button>
@@ -234,10 +184,8 @@ const HomeList: FC = () => {
                         variant="ghost"
                         size="sm"
                         leftIcon={<X size={14} />}
-                        isLoading={isCancelling}
-                        disabled={isCancelling}
                         data-testid={`home-cancel-${rec.id}`}
-                        onClick={() => void cancelJob(job)}
+                        onClick={() => cancelJob(job)}
                       >
                         {t("queue.cancel")}
                       </Button>
@@ -249,7 +197,7 @@ const HomeList: FC = () => {
                       isLoading={isDeleting}
                       disabled={isDeleting}
                       data-testid={`home-delete-${rec.id}`}
-                      onClick={() => void deleteRecording(rec)}
+                      onClick={() => deleteRecording(rec)}
                     >
                       {t("common.delete")}
                     </Button>

--- a/frontend/src/features/Home/__tests__/HomeList.test.tsx
+++ b/frontend/src/features/Home/__tests__/HomeList.test.tsx
@@ -1,0 +1,192 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import HomeList from "../HomeList";
+import { lightTheme } from "../../../styles/theme";
+import type { ProcessingJob } from "../../../domain/ProcessingJob";
+import type { Recording } from "../../../domain/Recording";
+import { loadRecordings, deleteRecording } from "../../../store/slices/recording";
+import { cancelJob as cancelJobAction, jobUpdated } from "../../../store/slices/jobs";
+import { openNoteRequested } from "../../../store/slices/ui";
+import {
+  renderWithStore,
+  mockRecordingState,
+  mockJobsState,
+  recordingsById,
+  jobsById,
+  mergeMockState,
+} from "../../../testUtils";
+import "../../../i18n";
+import { MemoryRouter } from "react-router-dom";
+
+jest.mock("react-toastify", () => ({
+  toast: {
+    error: jest.fn(),
+    success: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
+  ToastContainer: () => null,
+}));
+
+const buildRecording = (patch: Partial<Recording> = {}): Recording => ({
+  id: patch.id ?? "rec-1",
+  fileName: patch.fileName ?? "test-recording.mp3",
+  filePath: patch.filePath ?? "/tmp/test-recording.mp3",
+  sha256: patch.sha256 ?? "abc123",
+  duration: patch.duration ?? "00:01:00",
+  format: patch.format ?? "Mp3",
+  sourceType: patch.sourceType ?? "Recorded",
+  status: patch.status ?? "New",
+  createdAt: patch.createdAt ?? new Date("2026-04-17T12:00:00Z").toISOString(),
+});
+
+const buildJob = (patch: Partial<ProcessingJob> = {}): ProcessingJob => ({
+  id: patch.id ?? "job-1",
+  recordingId: patch.recordingId ?? "rec-1",
+  profileId: patch.profileId ?? "profile-default",
+  status: patch.status ?? "Queued",
+  progress: patch.progress ?? 0,
+  currentStep: patch.currentStep ?? null,
+  errorMessage: patch.errorMessage ?? null,
+  userHint: patch.userHint ?? null,
+  createdAt: patch.createdAt ?? new Date("2026-04-17T12:00:00Z").toISOString(),
+  startedAt: patch.startedAt ?? null,
+  finishedAt: patch.finishedAt ?? null,
+  resumedFromCheckpoint: patch.resumedFromCheckpoint,
+  checkpointAt: patch.checkpointAt,
+});
+
+const renderHomeList = (
+  preloadedState: Partial<import("../../../store/rootReducer").GlobalState> = {}
+) =>
+  renderWithStore(
+    <MemoryRouter>
+      <HomeList />
+    </MemoryRouter>,
+    { preloadedState, theme: lightTheme }
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("HomeList — on mount", () => {
+  it("HomeList_OnMount_DispatchesLoadRecordings", () => {
+    const { getActions } = renderHomeList();
+    expect(getActions()).toContainEqual(loadRecordings());
+  });
+});
+
+describe("HomeList — rendering from store", () => {
+  it("HomeList_RendersRecordingsFromStore", async () => {
+    const rec1 = buildRecording({ id: "rec-a", fileName: "alpha.mp3" });
+    const rec2 = buildRecording({ id: "rec-b", fileName: "beta.mp3" });
+    renderHomeList(
+      mergeMockState(mockRecordingState({ recordings: recordingsById([rec1, rec2]) }))
+    );
+
+    expect(await screen.findByText("alpha.mp3")).toBeInTheDocument();
+    expect(screen.getByText("beta.mp3")).toBeInTheDocument();
+  });
+});
+
+describe("HomeList — delete", () => {
+  it("HomeList_DeleteClick_ConfirmsAndDispatchesDeleteAction", async () => {
+    const rec = buildRecording({ id: "rec-del-1" });
+    const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
+
+    const { getActions } = renderHomeList(
+      mergeMockState(mockRecordingState({ recordings: recordingsById([rec]) }))
+    );
+
+    const deleteBtn = await screen.findByTestId(`home-delete-${rec.id}`);
+    await userEvent.click(deleteBtn);
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(getActions()).toContainEqual(deleteRecording(rec.id));
+
+    confirmSpy.mockRestore();
+  });
+
+  it("HomeList_DeleteDeclined_DoesNotDispatch", async () => {
+    const rec = buildRecording({ id: "rec-del-2" });
+    const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(false);
+
+    const { getActions } = renderHomeList(
+      mergeMockState(mockRecordingState({ recordings: recordingsById([rec]) }))
+    );
+
+    const deleteBtn = await screen.findByTestId(`home-delete-${rec.id}`);
+    await userEvent.click(deleteBtn);
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(getActions()).not.toContainEqual(deleteRecording(rec.id));
+
+    confirmSpy.mockRestore();
+  });
+});
+
+describe("HomeList — cancel", () => {
+  it("HomeList_CancelClick_OnQueuedJob_DispatchesCancelAction", async () => {
+    const rec = buildRecording({ id: "rec-cancel-1" });
+    const job = buildJob({ id: "job-cancel-1", recordingId: "rec-cancel-1", status: "Queued" });
+
+    const { getActions } = renderHomeList(
+      mergeMockState(
+        mockRecordingState({ recordings: recordingsById([rec]) }),
+        mockJobsState({ byId: jobsById([job]) })
+      )
+    );
+
+    const cancelBtn = await screen.findByTestId(`home-cancel-${rec.id}`);
+    await userEvent.click(cancelBtn);
+
+    expect(getActions()).toContainEqual(cancelJobAction(job.id));
+  });
+});
+
+describe("HomeList — open note", () => {
+  it("HomeList_OpenNoteClick_OnDoneRecording_DispatchesOpenNoteRequested", async () => {
+    const rec = buildRecording({ id: "rec-note-1" });
+    const job = buildJob({
+      id: "job-note-1",
+      recordingId: "rec-note-1",
+      status: "Done",
+      progress: 100,
+    });
+
+    const { getActions } = renderHomeList(
+      mergeMockState(
+        mockRecordingState({ recordings: recordingsById([rec]) }),
+        mockJobsState({ byId: jobsById([job]) })
+      )
+    );
+
+    const openNoteBtn = await screen.findByTestId(`home-open-note-${rec.id}`);
+    await userEvent.click(openNoteBtn);
+
+    expect(getActions()).toContainEqual(openNoteRequested(rec.id));
+  });
+});
+
+describe("HomeList — subscription push", () => {
+  it("HomeList_SubscriptionPush_UpdatesRowStatus", async () => {
+    const rec = buildRecording({ id: "rec-live-1" });
+
+    const { store } = renderHomeList(
+      mergeMockState(mockRecordingState({ recordings: recordingsById([rec]) }))
+    );
+
+    const job = buildJob({
+      id: "job-live-1",
+      recordingId: "rec-live-1",
+      status: "Transcribing",
+      progress: 40,
+    });
+
+    store.dispatch(jobUpdated(job) as never);
+
+    await waitFor(() => expect(screen.getByTestId(`home-cancel-${rec.id}`)).toBeInTheDocument());
+  });
+});

--- a/frontend/src/store/slices/recording/actions.ts
+++ b/frontend/src/store/slices/recording/actions.ts
@@ -4,6 +4,9 @@ export const LOAD_RECORDINGS = "recording/LOAD";
 export const LOAD_RECORDINGS_SUCCESS = "recording/LOAD_SUCCESS";
 export const LOAD_RECORDINGS_FAILURE = "recording/LOAD_FAILURE";
 export const LOAD_RECORDINGS_UNAVAILABLE = "recording/LOAD_UNAVAILABLE";
+export const DELETE_RECORDING = "recording/DELETE";
+export const DELETE_RECORDING_SUCCESS = "recording/DELETE_SUCCESS";
+export const DELETE_RECORDING_FAILURE = "recording/DELETE_FAILURE";
 
 export interface LoadRecordingsAction {
   type: typeof LOAD_RECORDINGS;
@@ -23,11 +26,29 @@ export interface LoadRecordingsUnavailableAction {
   type: typeof LOAD_RECORDINGS_UNAVAILABLE;
 }
 
+export interface DeleteRecordingAction {
+  type: typeof DELETE_RECORDING;
+  payload: string;
+}
+
+export interface DeleteRecordingSuccessAction {
+  type: typeof DELETE_RECORDING_SUCCESS;
+  payload: string;
+}
+
+export interface DeleteRecordingFailureAction {
+  type: typeof DELETE_RECORDING_FAILURE;
+  payload: { id: string; error: string };
+}
+
 export type RecordingAction =
   | LoadRecordingsAction
   | LoadRecordingsSuccessAction
   | LoadRecordingsFailureAction
-  | LoadRecordingsUnavailableAction;
+  | LoadRecordingsUnavailableAction
+  | DeleteRecordingAction
+  | DeleteRecordingSuccessAction
+  | DeleteRecordingFailureAction;
 
 export const loadRecordings = (): LoadRecordingsAction => ({
   type: LOAD_RECORDINGS,
@@ -45,4 +66,22 @@ export const loadRecordingsFailure = (message: string): LoadRecordingsFailureAct
 
 export const loadRecordingsUnavailable = (): LoadRecordingsUnavailableAction => ({
   type: LOAD_RECORDINGS_UNAVAILABLE,
+});
+
+export const deleteRecording = (id: string): DeleteRecordingAction => ({
+  type: DELETE_RECORDING,
+  payload: id,
+});
+
+export const deleteRecordingSuccess = (id: string): DeleteRecordingSuccessAction => ({
+  type: DELETE_RECORDING_SUCCESS,
+  payload: id,
+});
+
+export const deleteRecordingFailure = (payload: {
+  id: string;
+  error: string;
+}): DeleteRecordingFailureAction => ({
+  type: DELETE_RECORDING_FAILURE,
+  payload,
 });

--- a/frontend/src/store/slices/recording/index.ts
+++ b/frontend/src/store/slices/recording/index.ts
@@ -2,4 +2,4 @@ export * from "./actions";
 export * from "./selectors";
 export * from "./types";
 export { recordingReducer } from "./reducer";
-export { watchRecordingSagas, loadRecordingsSaga } from "./saga";
+export { watchRecordingSagas, loadRecordingsSaga, deleteRecordingSaga } from "./saga";

--- a/frontend/src/store/slices/recording/reducer.ts
+++ b/frontend/src/store/slices/recording/reducer.ts
@@ -1,5 +1,8 @@
 import type { Reducer } from "redux";
 import {
+  DELETE_RECORDING,
+  DELETE_RECORDING_FAILURE,
+  DELETE_RECORDING_SUCCESS,
   LOAD_RECORDINGS,
   LOAD_RECORDINGS_FAILURE,
   LOAD_RECORDINGS_SUCCESS,
@@ -50,6 +53,32 @@ export const recordingReducer: Reducer<RecordingState> = (
         isBackendUnavailable: true,
         recordings: {},
       };
+    case DELETE_RECORDING: {
+      const id = (typed as { payload: string }).payload;
+      return {
+        ...state,
+        deletingIds: { ...state.deletingIds, [id]: true },
+      };
+    }
+    case DELETE_RECORDING_SUCCESS: {
+      const id = (typed as { payload: string }).payload;
+      const { [id]: _removed, ...restRecordings } = state.recordings;
+      const { [id]: _removedDeleting, ...restDeletingIds } = state.deletingIds;
+      return {
+        ...state,
+        recordings: restRecordings,
+        deletingIds: restDeletingIds,
+      };
+    }
+    case DELETE_RECORDING_FAILURE: {
+      const { id } = (typed as { payload: { id: string; error: string } }).payload;
+      const { [id]: _removedDeleting, ...restDeletingIds } = state.deletingIds;
+      return {
+        ...state,
+        deletingIds: restDeletingIds,
+        error: (typed as { payload: { id: string; error: string } }).payload.error,
+      };
+    }
     default:
       return state;
   }

--- a/frontend/src/store/slices/recording/saga.ts
+++ b/frontend/src/store/slices/recording/saga.ts
@@ -1,14 +1,18 @@
-import { put, takeLatest } from "redux-saga/effects";
+import { put, takeEvery, takeLatest } from "redux-saga/effects";
 import type { SagaIterator } from "redux-saga";
 
 import type { QueryRecordingsQuery } from "../../../api/gql/graphql";
-import { QueryRecordingsDocument } from "../../../api/gql/graphql";
+import { MutationDeleteRecordingDocument, QueryRecordingsDocument } from "../../../api/gql/graphql";
 import { gqlRequest } from "../../saga/graphql";
 import {
+  DELETE_RECORDING,
   LOAD_RECORDINGS,
+  deleteRecordingFailure,
+  deleteRecordingSuccess,
   loadRecordingsFailure,
   loadRecordingsSuccess,
   loadRecordingsUnavailable,
+  type DeleteRecordingAction,
 } from "./actions";
 import { mapGqlRecording } from "./recordingMapper";
 
@@ -30,6 +34,17 @@ export function* loadRecordingsSaga(): SagaIterator {
   }
 }
 
+export function* deleteRecordingSaga(action: DeleteRecordingAction): SagaIterator {
+  const id = action.payload;
+  try {
+    yield* gqlRequest(MutationDeleteRecordingDocument, { id });
+    yield put(deleteRecordingSuccess(id));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    yield put(deleteRecordingFailure({ id, error: message }));
+  }
+}
+
 const isBackendDown = (error: unknown): boolean => {
   if (error instanceof Error) {
     return (
@@ -44,4 +59,5 @@ const isBackendDown = (error: unknown): boolean => {
 
 export function* watchRecordingSagas(): SagaIterator {
   yield takeLatest(LOAD_RECORDINGS, loadRecordingsSaga);
+  yield takeEvery(DELETE_RECORDING, deleteRecordingSaga);
 }

--- a/frontend/src/store/slices/recording/selectors.ts
+++ b/frontend/src/store/slices/recording/selectors.ts
@@ -22,3 +22,11 @@ export const selectBackendUnavailable = createSelector(
 
 export const selectRecordingById = (id: string) =>
   createSelector(selectRecordingState, (slice) => slice.recordings[id] ?? null);
+
+export const selectDeletingRecordingIds = createSelector(
+  selectRecordingState,
+  (slice) => slice.deletingIds
+);
+
+export const selectIsDeletingRecording = (id: string) =>
+  createSelector(selectRecordingState, (slice) => slice.deletingIds[id] === true);

--- a/frontend/src/store/slices/recording/types.ts
+++ b/frontend/src/store/slices/recording/types.ts
@@ -5,6 +5,7 @@ export interface RecordingState {
   isLoading: boolean;
   isBackendUnavailable: boolean;
   error: string | null;
+  deletingIds: Record<string, true>;
 }
 
 export const initialRecordingState: RecordingState = {
@@ -12,4 +13,5 @@ export const initialRecordingState: RecordingState = {
   isLoading: false,
   isBackendUnavailable: false,
   error: null,
+  deletingIds: {},
 };

--- a/frontend/src/store/slices/ui/actions.ts
+++ b/frontend/src/store/slices/ui/actions.ts
@@ -5,6 +5,10 @@ export const OPEN_MODAL = "ui/OPEN_MODAL";
 export const CLOSE_MODAL = "ui/CLOSE_MODAL";
 export const PUSH_TOAST = "ui/PUSH_TOAST";
 export const DISMISS_TOAST = "ui/DISMISS_TOAST";
+export const OPEN_NOTE_REQUESTED = "ui/OPEN_NOTE_REQUESTED";
+export const OPEN_NOTE_RESOLVED = "ui/OPEN_NOTE_RESOLVED";
+export const OPEN_NOTE_FAILED = "ui/OPEN_NOTE_FAILED";
+export const CLEAR_OPEN_NOTE_RESOLUTION = "ui/CLEAR_OPEN_NOTE_RESOLUTION";
 
 export interface SetThemeModeAction {
   type: typeof SET_THEME_MODE;
@@ -31,12 +35,36 @@ export interface DismissToastAction {
   payload: { id: string };
 }
 
+export interface OpenNoteRequestedAction {
+  type: typeof OPEN_NOTE_REQUESTED;
+  payload: string;
+}
+
+export interface OpenNoteResolvedAction {
+  type: typeof OPEN_NOTE_RESOLVED;
+  payload: { recordingId: string; firstNoteId: string | null };
+}
+
+export interface OpenNoteFailedAction {
+  type: typeof OPEN_NOTE_FAILED;
+  payload: { recordingId: string; error: string };
+}
+
+export interface ClearOpenNoteResolutionAction {
+  type: typeof CLEAR_OPEN_NOTE_RESOLUTION;
+  payload: string;
+}
+
 export type UiAction =
   | SetThemeModeAction
   | OpenModalAction
   | CloseModalAction
   | PushToastAction
-  | DismissToastAction;
+  | DismissToastAction
+  | OpenNoteRequestedAction
+  | OpenNoteResolvedAction
+  | OpenNoteFailedAction
+  | ClearOpenNoteResolutionAction;
 
 export const setThemeMode = (mode: ThemeMode): SetThemeModeAction => ({
   type: SET_THEME_MODE,
@@ -61,4 +89,27 @@ export const pushToast = (toast: ToastEntry): PushToastAction => ({
 export const dismissToast = (id: string): DismissToastAction => ({
   type: DISMISS_TOAST,
   payload: { id },
+});
+
+export const openNoteRequested = (recordingId: string): OpenNoteRequestedAction => ({
+  type: OPEN_NOTE_REQUESTED,
+  payload: recordingId,
+});
+
+export const openNoteResolved = (
+  recordingId: string,
+  firstNoteId: string | null
+): OpenNoteResolvedAction => ({
+  type: OPEN_NOTE_RESOLVED,
+  payload: { recordingId, firstNoteId },
+});
+
+export const openNoteFailed = (recordingId: string, error: string): OpenNoteFailedAction => ({
+  type: OPEN_NOTE_FAILED,
+  payload: { recordingId, error },
+});
+
+export const clearOpenNoteResolution = (recordingId: string): ClearOpenNoteResolutionAction => ({
+  type: CLEAR_OPEN_NOTE_RESOLUTION,
+  payload: recordingId,
 });

--- a/frontend/src/store/slices/ui/reducer.ts
+++ b/frontend/src/store/slices/ui/reducer.ts
@@ -1,9 +1,13 @@
 import type { Reducer } from "redux";
 
 import {
+  CLEAR_OPEN_NOTE_RESOLUTION,
   CLOSE_MODAL,
   DISMISS_TOAST,
   OPEN_MODAL,
+  OPEN_NOTE_FAILED,
+  OPEN_NOTE_REQUESTED,
+  OPEN_NOTE_RESOLVED,
   PUSH_TOAST,
   SET_THEME_MODE,
   type UiAction,
@@ -24,6 +28,47 @@ export const uiReducer: Reducer<UiState> = (state: UiState = initialUiState, act
       return addToast(state, typed.payload);
     case DISMISS_TOAST:
       return removeToast(state, typed.payload.id);
+    case OPEN_NOTE_REQUESTED: {
+      const recordingId = (typed as { payload: string }).payload;
+      return {
+        ...state,
+        openNoteResolutions: {
+          ...state.openNoteResolutions,
+          [recordingId]: { status: "pending" },
+        },
+      };
+    }
+    case OPEN_NOTE_RESOLVED: {
+      const { recordingId, firstNoteId } = (
+        typed as { payload: { recordingId: string; firstNoteId: string | null } }
+      ).payload;
+      return {
+        ...state,
+        openNoteResolutions: {
+          ...state.openNoteResolutions,
+          [recordingId]: { status: "resolved", firstNoteId },
+        },
+      };
+    }
+    case OPEN_NOTE_FAILED: {
+      const { recordingId, error } = (typed as { payload: { recordingId: string; error: string } })
+        .payload;
+      return {
+        ...state,
+        openNoteResolutions: {
+          ...state.openNoteResolutions,
+          [recordingId]: { status: "failed", error },
+        },
+      };
+    }
+    case CLEAR_OPEN_NOTE_RESOLUTION: {
+      const recordingId = (typed as { payload: string }).payload;
+      const { [recordingId]: _removed, ...rest } = state.openNoteResolutions;
+      return {
+        ...state,
+        openNoteResolutions: rest,
+      };
+    }
     default:
       return state;
   }

--- a/frontend/src/store/slices/ui/saga/index.ts
+++ b/frontend/src/store/slices/ui/saga/index.ts
@@ -1,3 +1,8 @@
+import { all, fork } from "redux-saga/effects";
 import type { SagaIterator } from "redux-saga";
 
-export function* watchUiSagas(): SagaIterator {}
+import { watchOpenNoteSagas } from "./openNoteSaga";
+
+export function* watchUiSagas(): SagaIterator {
+  yield all([fork(watchOpenNoteSagas)]);
+}

--- a/frontend/src/store/slices/ui/saga/openNoteSaga.ts
+++ b/frontend/src/store/slices/ui/saga/openNoteSaga.ts
@@ -1,0 +1,30 @@
+import { put, takeEvery } from "redux-saga/effects";
+import type { SagaIterator } from "redux-saga";
+
+import type { QueryRecordingWithNotesQuery } from "../../../../api/gql/graphql";
+import { QueryRecordingWithNotesDocument } from "../../../../api/gql/graphql";
+import { gqlRequest } from "../../../saga/graphql";
+import {
+  OPEN_NOTE_REQUESTED,
+  openNoteFailed,
+  openNoteResolved,
+  type OpenNoteRequestedAction,
+} from "../actions";
+
+export function* openNoteSaga(action: OpenNoteRequestedAction): SagaIterator {
+  const recordingId = action.payload;
+  try {
+    const result = (yield* gqlRequest(QueryRecordingWithNotesDocument, {
+      id: recordingId,
+    })) as QueryRecordingWithNotesQuery;
+    const firstNoteId = result.recording?.notes[0]?.id ?? null;
+    yield put(openNoteResolved(recordingId, firstNoteId));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    yield put(openNoteFailed(recordingId, message));
+  }
+}
+
+export function* watchOpenNoteSagas(): SagaIterator {
+  yield takeEvery(OPEN_NOTE_REQUESTED, openNoteSaga);
+}

--- a/frontend/src/store/slices/ui/selectors.ts
+++ b/frontend/src/store/slices/ui/selectors.ts
@@ -9,3 +9,11 @@ export const selectOpenModals = createSelector(selectUiState, (slice) => slice.o
 export const selectIsModalOpen = (id: string) =>
   createSelector(selectUiState, (slice) => slice.openModals.includes(id));
 export const selectToasts = createSelector(selectUiState, (slice) => slice.toasts);
+
+export const selectAllOpenNoteResolutions = createSelector(
+  selectUiState,
+  (slice) => slice.openNoteResolutions
+);
+
+export const selectOpenNoteResolution = (recordingId: string) =>
+  createSelector(selectUiState, (slice) => slice.openNoteResolutions[recordingId] ?? null);

--- a/frontend/src/store/slices/ui/types.ts
+++ b/frontend/src/store/slices/ui/types.ts
@@ -6,14 +6,21 @@ export interface ToastEntry {
   readonly message: string;
 }
 
+export type OpenNoteResolution =
+  | { status: "pending" }
+  | { status: "resolved"; firstNoteId: string | null }
+  | { status: "failed"; error: string };
+
 export interface UiState {
   readonly themeMode: ThemeMode;
   readonly openModals: readonly string[];
   readonly toasts: readonly ToastEntry[];
+  readonly openNoteResolutions: Record<string, OpenNoteResolution>;
 }
 
 export const initialUiState: UiState = {
   themeMode: "system",
   openModals: [],
   toasts: [],
+  openNoteResolutions: {},
 };

--- a/frontend/src/testUtils/index.ts
+++ b/frontend/src/testUtils/index.ts
@@ -4,4 +4,11 @@ export { renderWithRouter } from "./renderWithRouter";
 export type { RenderWithRouterOptions } from "./renderWithRouter";
 export { createMockApi } from "./mockApi";
 export type { MockApiBundle } from "./mockApi";
-export { mockJobsState, jobsById } from "./mockState";
+export {
+  mockJobsState,
+  jobsById,
+  mockRecordingState,
+  recordingsById,
+  mockUiState,
+  mergeMockState,
+} from "./mockState";

--- a/frontend/src/testUtils/mockState.ts
+++ b/frontend/src/testUtils/mockState.ts
@@ -1,6 +1,9 @@
 import type { ProcessingJob } from "../domain/ProcessingJob";
+import type { Recording } from "../domain/Recording";
 import type { GlobalState } from "../store/rootReducer";
 import { initialJobsState, type JobsState } from "../store/slices/jobs";
+import { initialRecordingState, type RecordingState } from "../store/slices/recording";
+import { initialUiState, type UiState } from "../store/slices/ui";
 
 export const jobsById = (jobs: readonly ProcessingJob[]): Record<string, ProcessingJob> =>
   Object.fromEntries(jobs.map((job) => [job.id, job]));
@@ -8,3 +11,19 @@ export const jobsById = (jobs: readonly ProcessingJob[]): Record<string, Process
 export const mockJobsState = (patch: Partial<JobsState> = {}): Pick<GlobalState, "jobs"> => ({
   jobs: { ...initialJobsState, ...patch },
 });
+
+export const recordingsById = (recordings: readonly Recording[]): Record<string, Recording> =>
+  Object.fromEntries(recordings.map((rec) => [rec.id, rec]));
+
+export const mockRecordingState = (
+  patch: Partial<RecordingState> = {}
+): Pick<GlobalState, "recording"> => ({
+  recording: { ...initialRecordingState, ...patch },
+});
+
+export const mockUiState = (patch: Partial<UiState> = {}): Pick<GlobalState, "ui"> => ({
+  ui: { ...initialUiState, ...patch },
+});
+
+export const mergeMockState = (...parts: Partial<GlobalState>[]): Partial<GlobalState> =>
+  Object.assign({}, ...parts);


### PR DESCRIPTION
Pilot for #120 — HomeList + Dashboard migrated off direct `graphqlClient`.

## HomeList
- Reads `selectAllRecordings` / `selectAllJobs`; dispatches `loadRecordings` on mount and `RECORDINGS_CHANGED_EVENT`; delete / cancel / open-note via actions.
- `recording` slice: `DELETE_RECORDING` action + saga.
- `ui` slice: open-note resolution state + `openNoteSaga`.

## Dashboard
- New `dictation` slice (FSM: idle/starting/active/stopping/stopped/failed). Saga handles start/stop graphql. Component reacts to phase transitions for MediaRecorder setup/teardown.
- New `audioDevices` slice + subscription saga (bootstrapped in rootSaga). Component toasts on new `lastChange` via id-based transition detection.
- `recording` slice extended with upload/import flows; success refreshes list via dispatched `loadRecordings`.

## Tests
- `HomeList.test.tsx` (new) — action-dispatch + state-seeded render.
- `Dashboard.test.tsx` — rewritten on mockState + getActions, no `jest.mock` of transport.
- `Home.test.tsx` — stripped of transport stubs (both sub-components migrated).
- `testUtils/mockState.ts` extended: `mockRecordingState`, `recordingsById`, `mockUiState`, `mockDictationState`, `mockAudioDevicesState`, `mergeMockState`.

## Grep invariant
`grep -rnE "from .*graphqlClient|getGraphqlWsClient" src/features/Dashboard/ src/features/Home/` → zero hits.

## test plan
- [x] `npm run typecheck` / `npm run lint` / `npx prettier --check`
- [x] `bash scripts/agent-gate.sh frontend`
- [x] grep invariant holds

Refs #120.
