### PR TITLE
fix(dictation): dump-mode helper auto-build + hotkey ownership (#164)

### DIFF
--- a/frontend/electron/dictation/DumpModeOrchestrator.ts
+++ b/frontend/electron/dictation/DumpModeOrchestrator.ts
@@ -54,12 +54,23 @@ export class DumpModeOrchestrator {
     }
     if (!accelerator) return;
 
+    if (globalShortcut.isRegistered(accelerator)) {
+      console.info(
+        `[dump-mode] accelerator '${accelerator}' was claimed elsewhere in this process — taking ownership`
+      );
+      try {
+        globalShortcut.unregister(accelerator);
+      } catch (err) {
+        console.warn("[dump-mode] unregister conflicting accelerator failed:", err);
+      }
+    }
+
     const ok = globalShortcut.register(accelerator, () => {
       void this.handleToggle();
     });
     if (!ok) {
       console.warn(
-        `[dump-mode] failed to register toggle accelerator '${accelerator}' (already taken)`
+        `[dump-mode] failed to register toggle accelerator '${accelerator}' (already taken by another process / OS)`
       );
       return;
     }

--- a/frontend/electron/main.ts
+++ b/frontend/electron/main.ts
@@ -309,13 +309,6 @@ app.whenReady().then(async () => {
 
   createWindow();
 
-  const defaultHotkeyOk = registerGlobalDictationHotkey();
-  if (!defaultHotkeyOk) {
-    console.warn(
-      "[globalShortcut] Failed to register CommandOrControl+Shift+Space — likely a conflicting OS binding."
-    );
-  }
-
   if (process.platform === "darwin") {
     await initializeDictation();
     await initializeDumpMode();

--- a/scripts/demo.command
+++ b/scripts/demo.command
@@ -98,6 +98,20 @@ if command -v lefthook >/dev/null 2>&1; then
   (cd "$REPO_ROOT" && lefthook install >/dev/null 2>&1 || true)
 fi
 
+# --- Build Swift native helper on macOS (incremental; rebuilds only changed sources) ---
+if [ "$(uname)" = "Darwin" ] && command -v swift >/dev/null 2>&1; then
+  HELPER_PKG="$REPO_ROOT/native/MozgoslavDictationHelper"
+  if [ -d "$HELPER_PKG" ]; then
+    echo "→ building Swift dictation helper..."
+    swift build -c release --package-path "$HELPER_PKG"
+    HELPER_BIN_ARM="$HELPER_PKG/.build/arm64-apple-macosx/release/mozgoslav-dictation-helper"
+    HELPER_BIN_X86="$HELPER_PKG/.build/x86_64-apple-macosx/release/mozgoslav-dictation-helper"
+    [ -f "$HELPER_BIN_ARM" ] && chmod +x "$HELPER_BIN_ARM" || true
+    [ -f "$HELPER_BIN_X86" ] && chmod +x "$HELPER_BIN_X86" || true
+    echo "  ✓ helper built"
+  fi
+fi
+
 echo ""
 
 # Backend


### PR DESCRIPTION
Follow-up to merged #205. Closes the three things that kept dump-mode from actually working on a fresh `./scripts/demo.command` run:

1. `scripts/demo.command` now builds the Swift dictation helper, so `dumpHotkey.start` RPC actually exists at runtime (was missing → hold-to-record was a no-op for users who never run `swift build` manually).
2. Drops the unconditional hardcoded `CommandOrControl+Shift+Space` `globalShortcut` registration that was hijacking user presses before `DumpModeOrchestrator.bindToggle` could claim them.
3. `bindToggle` now does `unregister`-first-then-`register` so dump-mode wins the slot even if something else inside the process is still holding it.