### PR TITLE
feat: pipeline UX + demo flow polish (8 issues)

### DIFF
--- a/backend/src/Mozgoslav.Application/UseCases/ProcessQueueWorker.cs
+++ b/backend/src/Mozgoslav.Application/UseCases/ProcessQueueWorker.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -167,9 +168,20 @@ public sealed class ProcessQueueWorker
     }
 
     private bool _preflightPassed;
+    private HashSet<string>? _completedStageNames;
+
+    private bool IsStageAlreadyCompleted(string stageName)
+        => _completedStageNames?.Contains(stageName) == true;
 
     private async Task RunPipelineAsync(ProcessingJob job, CancellationToken ct)
     {
+        var completedStages = await _stages.GetByJobIdAsync(job.Id, ct);
+        _completedStageNames = new HashSet<string>(
+            completedStages
+                .Where(s => s.FinishedAt.HasValue && s.ErrorMessage == null)
+                .Select(s => s.StageName),
+            StringComparer.Ordinal);
+
         var recording = await _recordings.GetByIdAsync(job.RecordingId, ct)
             ?? throw new InvalidOperationException($"Recording {job.RecordingId} not found");
         var profile = await _profiles.GetByIdAsync(job.ProfileId, ct)
@@ -181,39 +193,57 @@ public sealed class ProcessQueueWorker
             return;
         }
 
-        await TransitionAsync(job, JobStatus.Transcribing, 0, "Transcribing audio", ct);
-        job.StartedAt = DateTime.UtcNow;
-        await _jobs.UpdateAsync(job, ct);
-
-        var wavPath = await _audioConverter.ConvertToWavAsync(recording.FilePath, ct);
-
-        var segmentProgress = new Progress<int>(p => _ = NotifyProgressAsync(job, ScaleProgress(p, 0, TranscribeEnd), ct));
-        var whisperInitialPrompt = _glossary.TryBuildInitialPrompt(profile, _settings.Language);
-        var segments = await _transcriptionService.TranscribeAsync(
-            wavPath, _settings.Language, whisperInitialPrompt, segmentProgress, ct);
-
-        var transcript = new Transcript
+        Transcript transcript;
+        if (IsStageAlreadyCompleted("Transcribing audio"))
         {
-            RecordingId = recording.Id,
-            ModelUsed = string.IsNullOrEmpty(_settings.WhisperModelPath)
-                ? "unknown"
-                : Path.GetFileName(_settings.WhisperModelPath),
-            Language = _settings.Language,
-            RawText = string.Join(" ", segments.Select(s => s.Text)).Trim(),
-            Segments = segments.ToList()
-        };
-        await _transcripts.AddAsync(transcript, ct);
+            transcript = await _transcripts.GetByRecordingIdAsync(recording.Id, ct)
+                ?? throw new InvalidOperationException($"Transcript for recording {recording.Id} not found on resume");
+        }
+        else
+        {
+            await TransitionAsync(job, JobStatus.Transcribing, 0, "Transcribing audio", ct);
+            job.StartedAt ??= DateTime.UtcNow;
+            await _jobs.UpdateAsync(job, ct);
 
-        await TransitionAsync(job, JobStatus.Correcting, CorrectionEnd, "Cleaning transcript", ct);
+            var wavPath = await _audioConverter.ConvertToWavAsync(recording.FilePath, ct);
+
+            var segmentProgress = new Progress<int>(p => _ = NotifyProgressAsync(job, ScaleProgress(p, 0, TranscribeEnd), ct));
+            var whisperInitialPrompt = _glossary.TryBuildInitialPrompt(profile, _settings.Language);
+            var segments = await _transcriptionService.TranscribeAsync(
+                wavPath, _settings.Language, whisperInitialPrompt, segmentProgress, ct);
+
+            transcript = new Transcript
+            {
+                RecordingId = recording.Id,
+                ModelUsed = string.IsNullOrEmpty(_settings.WhisperModelPath)
+                    ? "unknown"
+                    : Path.GetFileName(_settings.WhisperModelPath),
+                Language = _settings.Language,
+                RawText = string.Join(" ", segments.Select(s => s.Text)).Trim(),
+                Segments = segments.ToList()
+            };
+            await _transcripts.AddAsync(transcript, ct);
+        }
+
+        if (!IsStageAlreadyCompleted("Cleaning transcript"))
+        {
+            await TransitionAsync(job, JobStatus.Correcting, CorrectionEnd, "Cleaning transcript", ct);
+        }
         var cleanText = _correctionService.Correct(transcript.RawText, profile);
 
         if (profile.LlmCorrectionEnabled && await _llmService.IsAvailableAsync(ct))
         {
-            await TransitionAsync(job, JobStatus.Correcting, LlmCorrectionEnd, "LLM correction", ct);
+            if (!IsStageAlreadyCompleted("LLM correction"))
+            {
+                await TransitionAsync(job, JobStatus.Correcting, LlmCorrectionEnd, "LLM correction", ct);
+            }
             cleanText = await _llmCorrection.CorrectAsync(cleanText, profile, ct, _settings.Language);
         }
 
-        await TransitionAsync(job, JobStatus.Summarizing, LlmCorrectionEnd, "Summarizing via LLM", ct);
+        if (!IsStageAlreadyCompleted("Summarizing via LLM"))
+        {
+            await TransitionAsync(job, JobStatus.Summarizing, LlmCorrectionEnd, "Summarizing via LLM", ct);
+        }
         LlmProcessingResult? llmResult = null;
         if (await _llmService.IsAvailableAsync(ct))
         {
@@ -231,23 +261,27 @@ public sealed class ProcessQueueWorker
         var note = BuildNote(transcript, profile, recording, cleanText, llmResult, version);
         note.MarkdownContent = MarkdownGenerator.Generate(note, profile, recording, transcript.Segments);
 
-        await TransitionAsync(job, JobStatus.Exporting, SummarizeEnd, "Exporting to vault", ct);
-        note.ExportedToVault = false;
-        note.VaultPath = null;
-        await _notes.AddAsync(note, ct);
-        await _eventBus.PublishAsync(new ProcessedNoteSaved(note.Id, profile.Id, DateTimeOffset.UtcNow), ct);
-
-        recording.Status = RecordingStatus.Transcribed;
-        if (segments.Count > 0)
+        if (!IsStageAlreadyCompleted("Exporting to vault"))
         {
-            recording.Duration = segments[^1].End;
+            await TransitionAsync(job, JobStatus.Exporting, SummarizeEnd, "Exporting to vault", ct);
+            note.ExportedToVault = false;
+            note.VaultPath = null;
+            await _notes.AddAsync(note, ct);
+            await _eventBus.PublishAsync(new ProcessedNoteSaved(note.Id, profile.Id, DateTimeOffset.UtcNow), ct);
+
+            recording.Status = RecordingStatus.Transcribed;
+            if (transcript.Segments.Count > 0)
+            {
+                recording.Duration = transcript.Segments[^1].End;
+            }
+            await _recordings.UpdateAsync(recording, ct);
         }
-        await _recordings.UpdateAsync(recording, ct);
 
         if (_settings.SidecarEnrichmentEnabled)
         {
             try
             {
+                var wavPath = await _audioConverter.ConvertToWavAsync(recording.FilePath, ct);
                 var enrichment = await _sidecarClient.ProcessAllAsync(wavPath, steps: null, ct);
                 _logger.LogInformation(
                     "Sidecar enrichment completed for job {JobId}: cleanedText={Len}ch embedding={Dim}d",

--- a/backend/src/Mozgoslav.Application/UseCases/ProcessQueueWorker.cs
+++ b/backend/src/Mozgoslav.Application/UseCases/ProcessQueueWorker.cs
@@ -127,12 +127,59 @@ public sealed class ProcessQueueWorker
         }
     }
 
+    private async Task RunPreflightChecksAsync(ProcessingJob job, CancellationToken ct)
+    {
+        await TransitionAsync(job, JobStatus.PreflightChecks, 0, "Preflight checks", ct);
+
+        var whisperPath = _settings.WhisperModelPath;
+        if (string.IsNullOrWhiteSpace(whisperPath) || !File.Exists(whisperPath))
+        {
+            var modelName = string.IsNullOrWhiteSpace(whisperPath)
+                ? "not configured"
+                : Path.GetFileName(whisperPath);
+            job.UserHint = $"Whisper model '{modelName}' missing. Settings → Models";
+            await MarkFailedAsync(job, $"Whisper model not found: {whisperPath}", ct);
+            return;
+        }
+
+        var vaultPath = _settings.VaultPath;
+        if (!string.IsNullOrWhiteSpace(vaultPath))
+        {
+            try
+            {
+                if (!Directory.Exists(vaultPath))
+                {
+                    Directory.CreateDirectory(vaultPath);
+                }
+                var probe = Path.Combine(vaultPath, ".mozgoslav-write-probe");
+                await File.WriteAllTextAsync(probe, string.Empty, ct);
+                File.Delete(probe);
+            }
+            catch (Exception ex)
+            {
+                job.UserHint = $"Vault path not writable: {vaultPath}";
+                await MarkFailedAsync(job, $"Vault path check failed: {ex.Message}", ct);
+                return;
+            }
+        }
+
+        _preflightPassed = true;
+    }
+
+    private bool _preflightPassed;
+
     private async Task RunPipelineAsync(ProcessingJob job, CancellationToken ct)
     {
         var recording = await _recordings.GetByIdAsync(job.RecordingId, ct)
             ?? throw new InvalidOperationException($"Recording {job.RecordingId} not found");
         var profile = await _profiles.GetByIdAsync(job.ProfileId, ct)
             ?? throw new InvalidOperationException($"Profile {job.ProfileId} not found");
+
+        await RunPreflightChecksAsync(job, ct);
+        if (!_preflightPassed)
+        {
+            return;
+        }
 
         await TransitionAsync(job, JobStatus.Transcribing, 0, "Transcribing audio", ct);
         job.StartedAt = DateTime.UtcNow;

--- a/backend/src/Mozgoslav.Application/UseCases/ProcessQueueWorker.cs
+++ b/backend/src/Mozgoslav.Application/UseCases/ProcessQueueWorker.cs
@@ -156,6 +156,10 @@ public sealed class ProcessQueueWorker
                 await File.WriteAllTextAsync(probe, string.Empty, ct);
                 File.Delete(probe);
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 job.UserHint = $"Vault path not writable: {vaultPath}";

--- a/backend/src/Mozgoslav.Domain/Enums/JobStatus.cs
+++ b/backend/src/Mozgoslav.Domain/Enums/JobStatus.cs
@@ -12,5 +12,6 @@ public enum JobStatus
     Exporting,
     Done,
     Failed,
-    Cancelled
+    Cancelled,
+    PreflightChecks
 }

--- a/backend/src/Mozgoslav.Domain/Enums/JobStatus.cs
+++ b/backend/src/Mozgoslav.Domain/Enums/JobStatus.cs
@@ -6,12 +6,12 @@ namespace Mozgoslav.Domain.Enums;
 public enum JobStatus
 {
     Queued,
+    PreflightChecks,
     Transcribing,
     Correcting,
     Summarizing,
     Exporting,
     Done,
     Failed,
-    Cancelled,
-    PreflightChecks
+    Cancelled
 }

--- a/backend/tests/Mozgoslav.Tests.Schema/__snapshots__/SchemaSnapshotTests.Schema_Matches_Snapshot.snap
+++ b/backend/tests/Mozgoslav.Tests.Schema/__snapshots__/SchemaSnapshotTests.Schema_Matches_Snapshot.snap
@@ -1214,6 +1214,7 @@ enum JobStatus {
   DONE
   FAILED
   CANCELLED
+  PREFLIGHT_CHECKS
 }
 
 enum ModelKind {

--- a/backend/tests/Mozgoslav.Tests/Application/ProcessQueueWorkerTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Application/ProcessQueueWorkerTests.cs
@@ -270,8 +270,88 @@ public sealed class ProcessQueueWorkerTests
         job.ErrorMessage.Should().BeNull();
     }
 
-    private sealed class Fixture
+    [TestMethod]
+    public async Task ProcessJobAsync_MissingWhisperModel_FailsAtPreflightWithUserHint()
     {
+        using var fixture = new Fixture();
+        var job = fixture.SeedJob();
+
+        fixture.Settings.VaultPath.Returns(fixture.VaultPath);
+        fixture.Settings.Language.Returns("ru");
+        fixture.Settings.WhisperModelPath.Returns("/nonexistent/path/ggml-small-q8_0.bin");
+
+        fixture.Recordings.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new Recording
+            {
+                FileName = "test.m4a",
+                FilePath = "/tmp/test.m4a",
+                Sha256 = "deadbeef",
+                Format = AudioFormat.M4A,
+                SourceType = SourceType.Imported
+            });
+
+        fixture.Profiles.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new Profile
+            {
+                Name = "Test",
+                CleanupLevel = CleanupLevel.Light,
+                SystemPrompt = "test prompt"
+            });
+
+        var started = DateTime.UtcNow;
+        await fixture.Worker.ProcessJobAsync(job.Id, CancellationToken.None);
+        var elapsed = DateTime.UtcNow - started;
+
+        job.Status.Should().Be(JobStatus.Failed);
+        job.UserHint.Should().Contain("ggml-small-q8_0.bin");
+        job.FinishedAt.Should().NotBeNull();
+        elapsed.Should().BeLessThan(TimeSpan.FromMilliseconds(100));
+        await fixture.Transcription.DidNotReceiveWithAnyArgs().TranscribeAsync(
+            default!, default!, default, default, default);
+    }
+
+    [TestMethod]
+    public async Task ProcessJobAsync_AllHealthy_ProgressesToTranscribing()
+    {
+        using var fixture = new Fixture();
+        var job = fixture.SeedJob();
+        fixture.ArrangeHappyPipeline();
+
+        JobStatus? statusAfterPreflight = null;
+        await fixture.Stages.AddAsync(
+            Arg.Do<ProcessingJobStage>(_ => { }),
+            Arg.Any<CancellationToken>());
+        await fixture.Jobs.UpdateAsync(
+            Arg.Do<ProcessingJob>(j =>
+            {
+                if (j.Status == JobStatus.Transcribing && statusAfterPreflight is null)
+                {
+                    statusAfterPreflight = j.Status;
+                }
+            }),
+            Arg.Any<CancellationToken>());
+
+        await fixture.Worker.ProcessJobAsync(job.Id, CancellationToken.None);
+
+        job.Status.Should().Be(JobStatus.Done);
+        statusAfterPreflight.Should().Be(JobStatus.Transcribing);
+    }
+
+    private sealed class Fixture : IDisposable
+    {
+        private readonly string _tempDir = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName());
+
+        public Fixture()
+        {
+            System.IO.Directory.CreateDirectory(_tempDir);
+        }
+
+        public void Dispose()
+        {
+            try { System.IO.Directory.Delete(_tempDir, true); } catch { }
+        }
+
         public IProcessingJobRepository Jobs { get; } = Substitute.For<IProcessingJobRepository>();
         public IProcessingJobStageRepository Stages { get; } = Substitute.For<IProcessingJobStageRepository>();
         public IRecordingRepository Recordings { get; } = Substitute.For<IRecordingRepository>();
@@ -287,7 +367,14 @@ public sealed class ProcessQueueWorkerTests
         public IPythonSidecarClient SidecarClient { get; } = Substitute.For<IPythonSidecarClient>();
         public TestJobCancellationRegistry CancellationRegistry { get; } = new();
 
-        public string VaultPath { get; init; } = "/tmp/vault";
+        public string VaultPath => _tempDir;
+
+        public string CreateModelFile(string name = "ggml-small-q8_0.bin")
+        {
+            var path = System.IO.Path.Combine(_tempDir, name);
+            System.IO.File.WriteAllText(path, "fake-model-data");
+            return path;
+        }
 
         public ProcessQueueWorker Worker => new(
             Jobs, Stages, Recordings, Transcripts, Notes, Profiles,
@@ -320,7 +407,7 @@ public sealed class ProcessQueueWorkerTests
         {
             Settings.VaultPath.Returns(VaultPath);
             Settings.Language.Returns("ru");
-            Settings.WhisperModelPath.Returns("/tmp/model.bin");
+            Settings.WhisperModelPath.Returns(CreateModelFile());
 
             Recordings.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
                 .Returns(new Recording

--- a/backend/tests/Mozgoslav.Tests/Application/ProcessQueueWorkerTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Application/ProcessQueueWorkerTests.cs
@@ -365,7 +365,7 @@ public sealed class ProcessQueueWorkerTests
 
         fixture.Stages.GetByJobIdAsync(job.Id, Arg.Any<CancellationToken>())
             .Returns([transcribeStage]);
-        fixture.Transcripts.GetByRecordingIdAsync(job.RecordingId, Arg.Any<CancellationToken>())
+        fixture.Transcripts.GetByRecordingIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(existingTranscript);
 
         await fixture.Worker.ProcessJobAsync(job.Id, CancellationToken.None);

--- a/backend/tests/Mozgoslav.Tests/Application/ProcessQueueWorkerTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Application/ProcessQueueWorkerTests.cs
@@ -26,7 +26,7 @@ public sealed class ProcessQueueWorkerTests
     [TestMethod]
     public async Task ProcessJobAsync_UnknownJob_IsNoOp()
     {
-        var fixture = new Fixture();
+        using var fixture = new Fixture();
         fixture.Jobs.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns((ProcessingJob?)null);
 
@@ -38,7 +38,7 @@ public sealed class ProcessQueueWorkerTests
     [TestMethod]
     public async Task ProcessJobAsync_AlreadyTerminal_IsNoOp()
     {
-        var fixture = new Fixture();
+        using var fixture = new Fixture();
         var job = fixture.SeedJob(JobStatus.Done);
 
         await fixture.Worker.ProcessJobAsync(job.Id, CancellationToken.None);
@@ -49,7 +49,7 @@ public sealed class ProcessQueueWorkerTests
     [TestMethod]
     public async Task ProcessJobAsync_HappyPath_RunsFullPipelineAndMarksJobDone()
     {
-        var fixture = new Fixture();
+        using var fixture = new Fixture();
         var job = fixture.SeedJob();
         fixture.ArrangeHappyPipeline();
 
@@ -70,7 +70,7 @@ public sealed class ProcessQueueWorkerTests
     [TestMethod]
     public async Task ProcessJobAsync_NoteVersion_StartsAtOne_WhenNoPriorNotesExist()
     {
-        var fixture = new Fixture();
+        using var fixture = new Fixture();
         var job = fixture.SeedJob();
         fixture.ArrangeHappyPipeline();
         fixture.Notes.GetByTranscriptIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
@@ -89,7 +89,7 @@ public sealed class ProcessQueueWorkerTests
     [TestMethod]
     public async Task ProcessJobAsync_NoteVersion_IncrementsPastLatest_OnReprocessing()
     {
-        var fixture = new Fixture();
+        using var fixture = new Fixture();
         var job = fixture.SeedJob();
         fixture.ArrangeHappyPipeline();
 
@@ -113,7 +113,7 @@ public sealed class ProcessQueueWorkerTests
     [TestMethod]
     public async Task ProcessJobAsync_LlmUnavailable_KeepsRawTranscriptAndStillProducesNote()
     {
-        var fixture = new Fixture();
+        using var fixture = new Fixture();
         var job = fixture.SeedJob();
         fixture.ArrangeHappyPipeline(llmAvailable: false);
 
@@ -134,7 +134,7 @@ public sealed class ProcessQueueWorkerTests
     [TestMethod]
     public async Task ProcessJobAsync_HappyPath_PersistsNoteWithExportFlagFalse()
     {
-        var fixture = new Fixture();
+        using var fixture = new Fixture();
         var job = fixture.SeedJob();
         fixture.ArrangeHappyPipeline();
 
@@ -154,7 +154,7 @@ public sealed class ProcessQueueWorkerTests
     [TestMethod]
     public async Task ProcessJobAsync_HappyPath_PublishesProcessedNoteSavedAfterAdd()
     {
-        var fixture = new Fixture();
+        using var fixture = new Fixture();
         var job = fixture.SeedJob();
         fixture.ArrangeHappyPipeline();
 
@@ -177,7 +177,7 @@ public sealed class ProcessQueueWorkerTests
     [TestMethod]
     public async Task ProcessJobAsync_UnknownRecording_MarksJobFailed()
     {
-        var fixture = new Fixture();
+        using var fixture = new Fixture();
         var job = fixture.SeedJob();
         fixture.Recordings.GetByIdAsync(job.RecordingId, Arg.Any<CancellationToken>())
             .Returns((Recording?)null);
@@ -192,7 +192,7 @@ public sealed class ProcessQueueWorkerTests
     [TestMethod]
     public async Task ProcessJobAsync_TranscriptionThrows_MarksJobFailedButDoesNotStallPipeline()
     {
-        var fixture = new Fixture();
+        using var fixture = new Fixture();
         var job = fixture.SeedJob();
         fixture.ArrangeHappyPipeline();
         fixture.Transcription
@@ -209,7 +209,7 @@ public sealed class ProcessQueueWorkerTests
     [TestMethod]
     public async Task ProcessJobAsync_WhenHostStopping_RethrowsCancellation()
     {
-        var fixture = new Fixture();
+        using var fixture = new Fixture();
         var job = fixture.SeedJob();
         fixture.ArrangeHappyPipeline();
         using var hostStopping = new CancellationTokenSource();
@@ -229,7 +229,7 @@ public sealed class ProcessQueueWorkerTests
     [TestMethod]
     public async Task ProcessJobAsync_WhenCancelRequestedBeforeTranscribe_MarksCancelled()
     {
-        var fixture = new Fixture();
+        using var fixture = new Fixture();
         var job = fixture.SeedJob();
         job.CancelRequested = true;
         fixture.ArrangeHappyPipeline();
@@ -247,7 +247,7 @@ public sealed class ProcessQueueWorkerTests
     [TestMethod]
     public async Task ProcessJobAsync_WhenTokenCancelledDuringTranscribe_MarksCancelled()
     {
-        var fixture = new Fixture();
+        using var fixture = new Fixture();
         var job = fixture.SeedJob();
         fixture.ArrangeHappyPipeline();
 
@@ -379,19 +379,25 @@ public sealed class ProcessQueueWorkerTests
 
     private sealed class Fixture : IDisposable
     {
-        private readonly string _tempDir = System.IO.Path.Combine(
-            System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName());
-
         public Fixture()
         {
-            System.IO.Directory.CreateDirectory(_tempDir);
+            System.IO.Directory.CreateDirectory(VaultPath);
             Stages.GetByJobIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
                 .Returns(Array.Empty<ProcessingJobStage>());
         }
 
         public void Dispose()
         {
-            try { System.IO.Directory.Delete(_tempDir, true); } catch { }
+            try
+            {
+                System.IO.Directory.Delete(VaultPath, true);
+            }
+            catch (System.IO.IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
         }
 
         public IProcessingJobRepository Jobs { get; } = Substitute.For<IProcessingJobRepository>();
@@ -409,11 +415,12 @@ public sealed class ProcessQueueWorkerTests
         public IPythonSidecarClient SidecarClient { get; } = Substitute.For<IPythonSidecarClient>();
         public TestJobCancellationRegistry CancellationRegistry { get; } = new();
 
-        public string VaultPath => _tempDir;
+        public string VaultPath { get; } = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName());
 
         public string CreateModelFile(string name = "ggml-small-q8_0.bin")
         {
-            var path = System.IO.Path.Combine(_tempDir, name);
+            var path = System.IO.Path.Combine(VaultPath, name);
             System.IO.File.WriteAllText(path, "fake-model-data");
             return path;
         }

--- a/backend/tests/Mozgoslav.Tests/Application/ProcessQueueWorkerTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Application/ProcessQueueWorkerTests.cs
@@ -337,6 +337,46 @@ public sealed class ProcessQueueWorkerTests
         statusAfterPreflight.Should().Be(JobStatus.Transcribing);
     }
 
+    [TestMethod]
+    public async Task ProcessJobAsync_ResumesFromLastFailedStage()
+    {
+        using var fixture = new Fixture();
+        var job = fixture.SeedJob();
+        fixture.ArrangeHappyPipeline();
+
+        var existingTranscript = new Transcript
+        {
+            RecordingId = job.RecordingId,
+            ModelUsed = "ggml-small-q8_0.bin",
+            Language = "ru",
+            RawText = "previously transcribed text",
+            Segments = []
+        };
+
+        var transcribeStage = new ProcessingJobStage
+        {
+            JobId = job.Id,
+            StageName = "Transcribing audio",
+            StartedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+            FinishedAt = DateTimeOffset.UtcNow.AddMinutes(-4),
+            DurationMs = 60_000,
+            ErrorMessage = null
+        };
+
+        fixture.Stages.GetByJobIdAsync(job.Id, Arg.Any<CancellationToken>())
+            .Returns([transcribeStage]);
+        fixture.Transcripts.GetByRecordingIdAsync(job.RecordingId, Arg.Any<CancellationToken>())
+            .Returns(existingTranscript);
+
+        await fixture.Worker.ProcessJobAsync(job.Id, CancellationToken.None);
+
+        job.Status.Should().Be(JobStatus.Done);
+        await fixture.Transcription.DidNotReceiveWithAnyArgs().TranscribeAsync(
+            default!, default!, default, default, default);
+        await fixture.Transcripts.DidNotReceiveWithAnyArgs().AddAsync(
+            default!, default);
+    }
+
     private sealed class Fixture : IDisposable
     {
         private readonly string _tempDir = System.IO.Path.Combine(
@@ -345,6 +385,8 @@ public sealed class ProcessQueueWorkerTests
         public Fixture()
         {
             System.IO.Directory.CreateDirectory(_tempDir);
+            Stages.GetByJobIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+                .Returns(Array.Empty<ProcessingJobStage>());
         }
 
         public void Dispose()

--- a/backend/tests/Mozgoslav.Tests/Domain/JobStatusTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Domain/JobStatusTests.cs
@@ -37,6 +37,7 @@ public sealed class JobStatusTests
         Enum.GetNames<JobStatus>().Should().BeEquivalentTo(
         [
             nameof(JobStatus.Queued),
+            nameof(JobStatus.PreflightChecks),
             nameof(JobStatus.Transcribing),
             nameof(JobStatus.Correcting),
             nameof(JobStatus.Summarizing),

--- a/backend/tests/Mozgoslav.Tests/UseCases/ProcessQueueWorkerEnrichmentTests.cs
+++ b/backend/tests/Mozgoslav.Tests/UseCases/ProcessQueueWorkerEnrichmentTests.cs
@@ -66,8 +66,11 @@ public sealed class ProcessQueueWorkerEnrichmentTests
         var sidecar = Substitute.For<IPythonSidecarClient>();
         var eventBus = Substitute.For<IDomainEventBus>();
 
+        var modelPath = Path.Combine(Path.GetTempPath(), $"mozgoslav-test-model-{Guid.NewGuid():N}.bin");
+        File.WriteAllText(modelPath, "fake-model");
+
         appSettings.Language.Returns("ru");
-        appSettings.WhisperModelPath.Returns(string.Empty);
+        appSettings.WhisperModelPath.Returns(modelPath);
         appSettings.SidecarEnrichmentEnabled.Returns(enrichmentEnabled);
 
         var profile = new Profile

--- a/docs/adr/ADR-EE-001-pipeline-preflight-and-resume.md
+++ b/docs/adr/ADR-EE-001-pipeline-preflight-and-resume.md
@@ -1,0 +1,48 @@
+# ADR-EE-001 — Pipeline preflight checks and idempotent stage resume
+
+## Context
+
+The processing pipeline (transcribe → correct → summarize → export) could fail silently
+when a required resource was missing (Whisper model not downloaded, vault path not writable).
+The user saw only a generic "Failed" status with no actionable hint.
+
+Additionally, if a job failed mid-pipeline, a full restart from the beginning was the only
+recovery path — even when expensive steps (transcription) had already completed successfully.
+
+## Decision
+
+### PreflightChecks stage (#239 #231)
+
+A `PreflightChecks` value is appended to the `JobStatus` enum (stored as string → no schema
+migration required). `RunPipelineAsync` calls `RunPreflightChecksAsync` before the first
+real stage. Checks performed in order:
+
+1. Whisper model file — `File.Exists(settings.WhisperModelPath)`. Failure sets
+   `ProcessingJob.UserHint` to a human-readable message ("Whisper model '…' missing.
+   Settings → Models") and marks the job `Failed` without throwing. No exception escapes.
+
+2. Vault path writeable — write + delete a probe file. Failure sets `UserHint` and marks
+   `Failed` without throwing.
+
+`UserError` surface: the `userHint` field on `ProcessingJob` is already exposed via
+GraphQL (see `JobQueryType`). Consumers read it and render it in the UI.
+
+### Idempotent stages + resume (#249)
+
+`RunPipelineAsync` queries `ProcessingJobStage` history at startup and skips stages where
+`FinishedAt != null && ErrorMessage == null`. This means a re-queued job resumes from the
+first incomplete or failed stage rather than restarting from scratch.
+
+The resume check happens after preflight so that preflight always reruns (resources may
+have changed since the last attempt).
+
+## Consequences
+
+- Jobs that fail preflight complete in < 100 ms with a user-visible hint.
+- Users do not need to diagnose cryptic exceptions — the hint text links to the Settings page.
+- Reprocessing jobs skip already-successful stages (e.g. transcription) saving time and
+  compute for downstream stages.
+- Existing `ProcessingJobStage` rows written by the old pipeline are compatible: rows with
+  `FinishedAt` set and no error are treated as completed.
+- Adding further preflight checks in future is a single-method addition with no schema
+  changes required.

--- a/frontend/electron/main.ts
+++ b/frontend/electron/main.ts
@@ -356,14 +356,24 @@ const applyCustomHotkeyFromSettings = async (): Promise<void> => {
   const delayMs = 750;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
-      const response = await fetch(`${BACKEND_ORIGIN}/api/settings`);
-      if (!response.ok) throw new Error(`status ${response.status}`);
-      const settings = (await response.json()) as {
+      const gqlResponse = await fetch(`${BACKEND_ORIGIN}/graphql`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          query:
+            "query QuerySettings { settings { dictationKeyboardHotkey dictationPushToTalk askCorpusHotkey } }",
+        }),
+      });
+      if (!gqlResponse.ok) throw new Error(`status ${gqlResponse.status}`);
+      const gqlBody = (await gqlResponse.json()) as {
+        data?: { settings?: { dictationKeyboardHotkey?: string; dictationPushToTalk?: boolean } };
+      };
+      const settingsTyped = (gqlBody.data?.settings ?? {}) as {
         dictationKeyboardHotkey?: string;
         dictationPushToTalk?: boolean;
       };
-      const custom = settings.dictationKeyboardHotkey?.trim() ?? "";
-      const pushToTalk = settings.dictationPushToTalk === true;
+      const custom = settingsTyped.dictationKeyboardHotkey?.trim() ?? "";
+      const pushToTalk = settingsTyped.dictationPushToTalk === true;
       console.info("=".repeat(70));
       console.info(
         `[hotkey] CHECKPOINT settings.custom='${custom}' settings.pushToTalk=${pushToTalk} orchestratorReady=${dictationOrchestrator !== null}`
@@ -522,12 +532,20 @@ const applyAskCorpusHotkeyFromSettings = async (): Promise<void> => {
   const defaultAccelerator = "CommandOrControl+Shift+/";
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
-      const response = await fetch(`${BACKEND_ORIGIN}/api/settings`);
-      if (!response.ok) throw new Error(`status ${response.status}`);
-      const settings = (await response.json()) as {
-        askCorpusHotkey?: string;
+      const gqlResponse = await fetch(`${BACKEND_ORIGIN}/graphql`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          query:
+            "query QuerySettings { settings { dictationKeyboardHotkey dictationPushToTalk askCorpusHotkey } }",
+        }),
+      });
+      if (!gqlResponse.ok) throw new Error(`status ${gqlResponse.status}`);
+      const gqlBody = (await gqlResponse.json()) as {
+        data?: { settings?: { askCorpusHotkey?: string } };
       };
-      const accelerator = settings.askCorpusHotkey?.trim() || defaultAccelerator;
+      const settingsTyped = (gqlBody.data?.settings ?? {}) as { askCorpusHotkey?: string };
+      const accelerator = settingsTyped.askCorpusHotkey?.trim() || defaultAccelerator;
 
       if (recordingHelper) {
         try {

--- a/frontend/electron/utils/backendLauncher.ts
+++ b/frontend/electron/utils/backendLauncher.ts
@@ -1,5 +1,6 @@
 import { type ChildProcess, execFile, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
+import { get as httpGet } from "node:http";
 import path from "node:path";
 
 import { restartSearxng } from "./searxngLauncher";
@@ -68,10 +69,28 @@ export interface BackendStartOptions {
   readonly extraEnv?: Readonly<Record<string, string>>;
 }
 
+const isBackendAlive = (): Promise<boolean> =>
+  new Promise((resolve) => {
+    const req = httpGet(`http://127.0.0.1:${BACKEND_PORT}/health`, (res) => {
+      res.resume();
+      resolve(res.statusCode === 200);
+    });
+    req.setTimeout(1500, () => {
+      req.destroy();
+      resolve(false);
+    });
+    req.on("error", () => resolve(false));
+  });
+
 export const tryStartBackend = async (
   userDataDir: string,
   options: BackendStartOptions = {}
 ): Promise<void> => {
+  if (process.env.MOZGOSLAV_BACKEND_ATTACH === "1" || await isBackendAlive()) {
+    console.info("[backendLauncher] backend already running on :5050, attaching");
+    return;
+  }
+
   const candidatePaths: string[] = [];
   if (options.resourcesRoot) {
     candidatePaths.push(

--- a/frontend/electron/utils/backendLauncher.ts
+++ b/frontend/electron/utils/backendLauncher.ts
@@ -86,7 +86,7 @@ export const tryStartBackend = async (
   userDataDir: string,
   options: BackendStartOptions = {}
 ): Promise<void> => {
-  if (process.env.MOZGOSLAV_BACKEND_ATTACH === "1" || await isBackendAlive()) {
+  if (process.env.MOZGOSLAV_BACKEND_ATTACH === "1" || (await isBackendAlive())) {
     console.info("[backendLauncher] backend already running on :5050, attaching");
     return;
   }

--- a/frontend/src/domain/enums.ts
+++ b/frontend/src/domain/enums.ts
@@ -2,6 +2,7 @@ export type CleanupLevel = "None" | "Light" | "Aggressive";
 export type ConversationType = "Meeting" | "OneOnOne" | "Idea" | "Personal" | "Other";
 export type JobStatus =
   | "Queued"
+  | "PreflightChecks"
   | "Transcribing"
   | "Correcting"
   | "Summarizing"

--- a/frontend/src/features/Home/LiveTranscript.tsx
+++ b/frontend/src/features/Home/LiveTranscript.tsx
@@ -3,12 +3,14 @@ import { useDispatch, useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import type { Dispatch } from "redux";
 
+import type { JobStatus } from "../../domain/enums";
 import {
   liveTranscriptSubscribe,
   liveTranscriptUnsubscribe,
   selectLivePartial,
   type RecordingAction,
 } from "../../store/slices/recording";
+import { selectJobByRecordingId } from "../../store/slices/jobs";
 import {
   LiveTranscriptDot,
   LiveTranscriptHeader,
@@ -20,11 +22,24 @@ export interface LiveTranscriptProps {
   recordingId: string;
 }
 
+const selectStatusLabel = (status: JobStatus | null, step: string | null, t: (key: string, opts?: Record<string, string>) => string): string => {
+  if (status === null) return t("recording.listening");
+  if (status === "Transcribing") return t("recording.processing.transcribing");
+  if (status === "Correcting" && step === "LLM correction") return t("recording.processing.llmCleanup");
+  if (status === "Correcting") return t("recording.processing.correcting");
+  if (status === "Summarizing") return t("recording.processing.summarizing");
+  if (status === "Exporting") return t("recording.processing.exporting");
+  if (status === "Failed") return t("recording.processing.failed", { step: step ?? "" });
+  return t("recording.listening");
+};
+
 const LiveTranscript: FC<LiveTranscriptProps> = ({ recordingId }) => {
   const { t } = useTranslation();
   const dispatch = useDispatch<Dispatch<RecordingAction>>();
   const partialSelector = useMemo(() => selectLivePartial(recordingId), [recordingId]);
   const partial = useSelector(partialSelector);
+  const jobSelector = useMemo(() => selectJobByRecordingId(recordingId), [recordingId]);
+  const job = useSelector(jobSelector);
 
   useEffect(() => {
     dispatch(liveTranscriptSubscribe(recordingId));
@@ -33,13 +48,15 @@ const LiveTranscript: FC<LiveTranscriptProps> = ({ recordingId }) => {
     };
   }, [dispatch, recordingId]);
 
+  const statusLabel = selectStatusLabel(job?.status ?? null, job?.currentStep ?? null, t);
+
   return (
     <LiveTranscriptRoot data-testid={`home-live-transcript-${recordingId}`}>
       <LiveTranscriptHeader>
         <LiveTranscriptDot />
         {t("home.liveTranscriptLabel")}
       </LiveTranscriptHeader>
-      <LiveTranscriptText>{partial?.text ?? t("home.liveTranscriptWaiting")}</LiveTranscriptText>
+      <LiveTranscriptText>{partial?.text ?? statusLabel}</LiveTranscriptText>
     </LiveTranscriptRoot>
   );
 };

--- a/frontend/src/features/Home/LiveTranscript.tsx
+++ b/frontend/src/features/Home/LiveTranscript.tsx
@@ -26,7 +26,8 @@ export interface LiveTranscriptProps {
 const selectStatusLabel = (status: JobStatus | null, step: string | null, t: TFunction): string => {
   if (status === null) return t("recording.listening");
   if (status === "Transcribing") return t("recording.processing.transcribing");
-  if (status === "Correcting" && step === "LLM correction") return t("recording.processing.llmCleanup");
+  if (status === "Correcting" && step === "LLM correction")
+    return t("recording.processing.llmCleanup");
   if (status === "Correcting") return t("recording.processing.correcting");
   if (status === "Summarizing") return t("recording.processing.summarizing");
   if (status === "Exporting") return t("recording.processing.exporting");

--- a/frontend/src/features/Home/LiveTranscript.tsx
+++ b/frontend/src/features/Home/LiveTranscript.tsx
@@ -1,6 +1,7 @@
 import { FC, useEffect, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
 import type { Dispatch } from "redux";
 
 import type { JobStatus } from "../../domain/enums";
@@ -22,7 +23,7 @@ export interface LiveTranscriptProps {
   recordingId: string;
 }
 
-const selectStatusLabel = (status: JobStatus | null, step: string | null, t: (key: string, opts?: Record<string, string>) => string): string => {
+const selectStatusLabel = (status: JobStatus | null, step: string | null, t: TFunction): string => {
   if (status === null) return t("recording.listening");
   if (status === "Transcribing") return t("recording.processing.transcribing");
   if (status === "Correcting" && step === "LLM correction") return t("recording.processing.llmCleanup");

--- a/frontend/src/features/Home/__tests__/LiveTranscript.test.tsx
+++ b/frontend/src/features/Home/__tests__/LiveTranscript.test.tsx
@@ -9,7 +9,15 @@ import {
   jobsById,
 } from "../../../testUtils";
 import type { ProcessingJob } from "../../../domain/ProcessingJob";
-import "../../../i18n";
+import i18n from "../../../i18n";
+
+beforeAll(async () => {
+  await i18n.changeLanguage("en");
+});
+
+afterAll(async () => {
+  await i18n.changeLanguage("ru");
+});
 
 jest.mock("../../../store/slices/recording/saga", () => ({
   watchRecordingSagas: function* () {},

--- a/frontend/src/features/Home/__tests__/LiveTranscript.test.tsx
+++ b/frontend/src/features/Home/__tests__/LiveTranscript.test.tsx
@@ -1,7 +1,13 @@
 import { screen } from "@testing-library/react";
 
 import LiveTranscript from "../LiveTranscript";
-import { renderWithStore, mergeMockState, mockRecordingState, mockJobsState, jobsById } from "../../../testUtils";
+import {
+  renderWithStore,
+  mergeMockState,
+  mockRecordingState,
+  mockJobsState,
+  jobsById,
+} from "../../../testUtils";
 import type { ProcessingJob } from "../../../domain/ProcessingJob";
 import "../../../i18n";
 
@@ -28,7 +34,9 @@ const renderLiveTranscript = (job: ProcessingJob | null, recordingId = "rec-1") 
     mockRecordingState(),
     mockJobsState(job ? { byId: jobsById([job]) } : {})
   );
-  return renderWithStore(<LiveTranscript recordingId={recordingId} />, { preloadedState: preloaded });
+  return renderWithStore(<LiveTranscript recordingId={recordingId} />, {
+    preloadedState: preloaded,
+  });
 };
 
 describe("LiveTranscript — context-aware status label", () => {

--- a/frontend/src/features/Home/__tests__/LiveTranscript.test.tsx
+++ b/frontend/src/features/Home/__tests__/LiveTranscript.test.tsx
@@ -1,0 +1,69 @@
+import { screen } from "@testing-library/react";
+
+import LiveTranscript from "../LiveTranscript";
+import { renderWithStore, mergeMockState, mockRecordingState, mockJobsState, jobsById } from "../../../testUtils";
+import type { ProcessingJob } from "../../../domain/ProcessingJob";
+import "../../../i18n";
+
+jest.mock("../../../store/slices/recording/saga", () => ({
+  watchRecordingSagas: function* () {},
+}));
+
+const buildJob = (patch: Partial<ProcessingJob> = {}): ProcessingJob => ({
+  id: patch.id ?? "job-1",
+  recordingId: patch.recordingId ?? "rec-1",
+  profileId: patch.profileId ?? "profile-1",
+  status: patch.status ?? "Queued",
+  progress: patch.progress ?? 0,
+  currentStep: patch.currentStep ?? null,
+  errorMessage: patch.errorMessage ?? null,
+  userHint: patch.userHint ?? null,
+  createdAt: patch.createdAt ?? new Date("2026-04-17T12:00:00Z").toISOString(),
+  startedAt: patch.startedAt ?? null,
+  finishedAt: patch.finishedAt ?? null,
+});
+
+const renderLiveTranscript = (job: ProcessingJob | null, recordingId = "rec-1") => {
+  const preloaded = mergeMockState(
+    mockRecordingState(),
+    mockJobsState(job ? { byId: jobsById([job]) } : {})
+  );
+  return renderWithStore(<LiveTranscript recordingId={recordingId} />, { preloadedState: preloaded });
+};
+
+describe("LiveTranscript — context-aware status label", () => {
+  it("shows listening label when no job exists", () => {
+    renderLiveTranscript(null);
+    expect(screen.getByText("Listening…")).toBeInTheDocument();
+  });
+
+  it("shows transcribing label when job status is Transcribing", () => {
+    const job = buildJob({ status: "Transcribing" });
+    renderLiveTranscript(job);
+    expect(screen.getByText("Transcribing audio…")).toBeInTheDocument();
+  });
+
+  it("shows correcting label when job status is Correcting", () => {
+    const job = buildJob({ status: "Correcting", currentStep: "Cleaning transcript" });
+    renderLiveTranscript(job);
+    expect(screen.getByText("Correcting…")).toBeInTheDocument();
+  });
+
+  it("shows LLM cleanup label when job status is Correcting with LLM step", () => {
+    const job = buildJob({ status: "Correcting", currentStep: "LLM correction" });
+    renderLiveTranscript(job);
+    expect(screen.getByText("LLM cleanup…")).toBeInTheDocument();
+  });
+
+  it("shows summarizing label when job status is Summarizing", () => {
+    const job = buildJob({ status: "Summarizing" });
+    renderLiveTranscript(job);
+    expect(screen.getByText("Summarizing…")).toBeInTheDocument();
+  });
+
+  it("shows exporting label when job status is Exporting", () => {
+    const job = buildJob({ status: "Exporting" });
+    renderLiveTranscript(job);
+    expect(screen.getByText("Exporting…")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/Models/Models.style.ts
+++ b/frontend/src/features/Models/Models.style.ts
@@ -7,6 +7,40 @@ export const PageRoot = styled.div`
   gap: ${({ theme }) => theme.space(4)};
 `;
 
+export const FilterRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${({ theme }) => theme.space(2)};
+`;
+
+export const FilterChip = styled.button<{ active: boolean }>`
+  padding: ${({ theme }) => `${theme.space(1)} ${theme.space(3)}`};
+  border-radius: 999px;
+  border: 1px solid ${({ theme, active }) =>
+    active ? theme.colors.accent.primary : theme.colors.border.subtle};
+  background: ${({ theme, active }) =>
+    active ? theme.colors.accent.primary : "transparent"};
+  color: ${({ theme, active }) =>
+    active ? theme.colors.accent.contrast : theme.colors.text.secondary};
+  font-size: ${({ theme }) => theme.font.size.sm};
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+
+  &:hover {
+    border-color: ${({ theme }) => theme.colors.accent.primary};
+    color: ${({ theme }) => theme.colors.accent.primary};
+  }
+`;
+
+export const GroupHeading = styled.h2`
+  margin: 0;
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.semibold};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  padding-bottom: ${({ theme }) => theme.space(1)};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border.subtle};
+`;
+
 export const PageTitle = styled.h1`
   margin: 0;
   font-size: ${({ theme }) => theme.font.size.xxl};

--- a/frontend/src/features/Models/Models.style.ts
+++ b/frontend/src/features/Models/Models.style.ts
@@ -16,15 +16,17 @@ export const FilterRow = styled.div`
 export const FilterChip = styled.button<{ active: boolean }>`
   padding: ${({ theme }) => `${theme.space(1)} ${theme.space(3)}`};
   border-radius: 999px;
-  border: 1px solid ${({ theme, active }) =>
-    active ? theme.colors.accent.primary : theme.colors.border.subtle};
-  background: ${({ theme, active }) =>
-    active ? theme.colors.accent.primary : "transparent"};
+  border: 1px solid
+    ${({ theme, active }) => (active ? theme.colors.accent.primary : theme.colors.border.subtle)};
+  background: ${({ theme, active }) => (active ? theme.colors.accent.primary : "transparent")};
   color: ${({ theme, active }) =>
     active ? theme.colors.accent.contrast : theme.colors.text.secondary};
   font-size: ${({ theme }) => theme.font.size.sm};
   cursor: pointer;
-  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
 
   &:hover {
     border-color: ${({ theme }) => theme.colors.accent.primary};

--- a/frontend/src/features/Models/Models.tsx
+++ b/frontend/src/features/Models/Models.tsx
@@ -38,7 +38,7 @@ const KIND_FILTER_VALUES = [
   ModelKind.NlpMl,
 ] as const;
 
-type FilterValue = typeof KIND_FILTER_VALUES[number] | "all";
+type FilterValue = (typeof KIND_FILTER_VALUES)[number] | "all";
 
 const Models: FC = () => {
   const { t } = useTranslation();
@@ -70,13 +70,10 @@ const Models: FC = () => {
   const filteredModels =
     activeFilter === "all" ? models : models.filter((m) => m.kind === activeFilter);
 
-  const groupedByKind = KIND_FILTER_VALUES.reduce<Record<string, typeof models>>(
-    (acc, kind) => {
-      acc[kind] = filteredModels.filter((m) => m.kind === kind);
-      return acc;
-    },
-    {}
-  );
+  const groupedByKind = KIND_FILTER_VALUES.reduce<Record<string, typeof models>>((acc, kind) => {
+    acc[kind] = filteredModels.filter((m) => m.kind === kind);
+    return acc;
+  }, {});
 
   const nonEmptyKinds = KIND_FILTER_VALUES.filter((k) => (groupedByKind[k]?.length ?? 0) > 0);
 

--- a/frontend/src/features/Models/Models.tsx
+++ b/frontend/src/features/Models/Models.tsx
@@ -1,6 +1,7 @@
-import { FC, useEffect } from "react";
+import { FC, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
+import { useSearchParams } from "react-router-dom";
 import type { Action, Dispatch } from "redux";
 import { Check, Download, HardDrive } from "lucide-react";
 
@@ -9,6 +10,7 @@ import Button from "../../components/Button";
 import Card from "../../components/Card";
 import EmptyState from "../../components/EmptyState";
 import ModelDownloadProgress from "../../components/ModelDownloadProgress";
+import { ModelKind } from "../../api/gql/graphql";
 import {
   downloadModel,
   loadModels,
@@ -16,17 +18,67 @@ import {
   selectActiveDownloadIdForModel,
   selectDownloadingModelId,
 } from "../../store/slices/models";
-import { ModelCard, ModelHeader, ModelMeta, PageRoot, PageTitle, Subtitle } from "./Models.style";
+import {
+  FilterChip,
+  FilterRow,
+  GroupHeading,
+  ModelCard,
+  ModelHeader,
+  ModelMeta,
+  PageRoot,
+  PageTitle,
+  Subtitle,
+} from "./Models.style";
+
+const KIND_FILTER_VALUES = [
+  ModelKind.Stt,
+  ModelKind.Llm,
+  ModelKind.Vad,
+  ModelKind.AudioMl,
+  ModelKind.NlpMl,
+] as const;
+
+type FilterValue = typeof KIND_FILTER_VALUES[number] | "all";
 
 const Models: FC = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch<Dispatch<Action>>();
   const models = useSelector(selectAllModels);
   const requestingDownloadId = useSelector(selectDownloadingModelId);
+  const [searchParams, setSearchParams] = useSearchParams();
 
   useEffect(() => {
     dispatch(loadModels());
   }, [dispatch]);
+
+  const rawType = searchParams.get("type");
+  const activeFilter: FilterValue = KIND_FILTER_VALUES.includes(rawType as ModelKind)
+    ? (rawType as ModelKind)
+    : "all";
+
+  const setFilter = useCallback(
+    (value: FilterValue) => {
+      if (value === "all") {
+        setSearchParams({});
+      } else {
+        setSearchParams({ type: value });
+      }
+    },
+    [setSearchParams]
+  );
+
+  const filteredModels =
+    activeFilter === "all" ? models : models.filter((m) => m.kind === activeFilter);
+
+  const groupedByKind = KIND_FILTER_VALUES.reduce<Record<string, typeof models>>(
+    (acc, kind) => {
+      acc[kind] = filteredModels.filter((m) => m.kind === kind);
+      return acc;
+    },
+    {}
+  );
+
+  const nonEmptyKinds = KIND_FILTER_VALUES.filter((k) => (groupedByKind[k]?.length ?? 0) > 0);
 
   return (
     <PageRoot>
@@ -34,22 +86,46 @@ const Models: FC = () => {
         <PageTitle>{t("models.title")}</PageTitle>
         <Subtitle>{t("models.subtitle")}</Subtitle>
       </div>
-      {models.length === 0 ? (
+      <FilterRow>
+        <FilterChip
+          active={activeFilter === "all"}
+          onClick={() => setFilter("all")}
+          data-testid="model-filter-all"
+        >
+          {t("models.filter.all")}
+        </FilterChip>
+        {KIND_FILTER_VALUES.map((kind) => (
+          <FilterChip
+            key={kind}
+            active={activeFilter === kind}
+            onClick={() => setFilter(kind)}
+            data-testid={`model-filter-${kind}`}
+          >
+            {t(`models.filter.${kind}`)}
+          </FilterChip>
+        ))}
+      </FilterRow>
+      {filteredModels.length === 0 ? (
         <EmptyState title={t("common.empty")} icon={<HardDrive size={28} />} />
       ) : (
-        models.map((model) => (
-          <ModelRow
-            key={model.id}
-            modelId={model.id}
-            modelName={model.name}
-            modelDescription={model.description}
-            modelSizeMb={model.sizeMb}
-            modelDestinationPath={model.destinationPath}
-            modelInstalled={model.installed}
-            modelIsDefault={model.isDefault}
-            requestingDownloadId={requestingDownloadId}
-            onDownload={() => dispatch(downloadModel(model.id))}
-          />
+        nonEmptyKinds.map((kind) => (
+          <div key={kind}>
+            <GroupHeading>{t(`models.filter.${kind}`)}</GroupHeading>
+            {groupedByKind[kind].map((model) => (
+              <ModelRow
+                key={model.id}
+                modelId={model.id}
+                modelName={model.name}
+                modelDescription={model.description}
+                modelSizeMb={model.sizeMb}
+                modelDestinationPath={model.destinationPath}
+                modelInstalled={model.installed}
+                modelIsDefault={model.isDefault}
+                requestingDownloadId={requestingDownloadId}
+                onDownload={() => dispatch(downloadModel(model.id))}
+              />
+            ))}
+          </div>
         ))
       )}
     </PageRoot>

--- a/frontend/src/features/Models/__tests__/Models.test.tsx
+++ b/frontend/src/features/Models/__tests__/Models.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 
 import Models from "../Models";
@@ -89,5 +90,75 @@ describe("Models page — store-driven", () => {
     renderModels();
 
     expect(screen.queryByTestId(/^model-download-/)).toBeNull();
+  });
+});
+
+const fakeModelLlm = {
+  __typename: "ModelEntry" as const,
+  id: "llama-model",
+  name: "LLaMA 3",
+  description: "LLM model",
+  url: "u2",
+  sizeMb: 4000,
+  kind: ModelKind.Llm,
+  tier: ModelTier.Downloadable,
+  isDefault: false,
+  destinationPath: "/models/llama.bin",
+  installed: false,
+};
+
+const renderModelsWithFilter = (initialUrl: string) =>
+  renderWithStore(
+    <MemoryRouter initialEntries={[initialUrl]}>
+      <Models />
+    </MemoryRouter>,
+    {
+      theme: darkTheme,
+      preloadedState: mergeMockState(
+        mockModelsState({
+          byId: {
+            [fakeModel.id]: fakeModel,
+            [fakeModelLlm.id]: fakeModelLlm,
+          },
+        })
+      ),
+    }
+  );
+
+describe("Models page — type filter chips", () => {
+  it("chip click filters list to matching kind", async () => {
+    const user = userEvent.setup();
+    renderModelsWithFilter("/models");
+
+    await user.click(screen.getByTestId("model-filter-STT"));
+
+    expect(screen.getByText("Whisper Small")).toBeInTheDocument();
+    expect(screen.queryByText("LLaMA 3")).not.toBeInTheDocument();
+  });
+
+  it("deeplink ?type=LLM applies filter on mount", () => {
+    renderModelsWithFilter("/models?type=LLM");
+
+    expect(screen.getByText("LLaMA 3")).toBeInTheDocument();
+    expect(screen.queryByText("Whisper Small")).not.toBeInTheDocument();
+  });
+
+  it("All chip shows all models", async () => {
+    const user = userEvent.setup();
+    renderModelsWithFilter("/models?type=LLM");
+
+    await user.click(screen.getByTestId("model-filter-all"));
+
+    expect(screen.getByText("Whisper Small")).toBeInTheDocument();
+    expect(screen.getByText("LLaMA 3")).toBeInTheDocument();
+  });
+
+  it("empty groups are hidden from the list", async () => {
+    const user = userEvent.setup();
+    renderModelsWithFilter("/models");
+
+    await user.click(screen.getByTestId("model-filter-STT"));
+
+    expect(screen.queryByText("LLaMA 3")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -115,6 +115,7 @@
     "resumedFrom": "Resumed from {{time}}",
     "status": {
       "Queued": "Queued",
+      "PreflightChecks": "Preflight checks",
       "Transcribing": "Transcribing",
       "Correcting": "Correcting",
       "Summarizing": "Summarizing",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -91,6 +91,18 @@
     "liveTranscriptLabel": "Live transcription",
     "liveTranscriptWaiting": "Listening…"
   },
+  "recording": {
+    "listening": "Listening…",
+    "processing": {
+      "transcribing": "Transcribing audio…",
+      "correcting": "Correcting…",
+      "llmCleanup": "LLM cleanup…",
+      "summarizing": "Summarizing…",
+      "exporting": "Exporting…",
+      "paused": "Paused",
+      "failed": "Failed at {{step}}"
+    }
+  },
   "dashboard": {
     "title": "Dashboard",
     "importTitle": "Add recording",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -350,7 +350,15 @@
     "installedButton": "Installed",
     "notInstalled": "Not downloaded",
     "download": "Download",
-    "sizeMb": "{{size}} MB"
+    "sizeMb": "{{size}} MB",
+    "filter": {
+      "all": "All",
+      "STT": "Whisper",
+      "LLM": "LLM",
+      "VAD": "VAD",
+      "AUDIO_ML": "Embedding",
+      "NLP_ML": "NLP"
+    }
   },
   "obsidian": {
     "title": "Obsidian vault",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -350,7 +350,15 @@
     "installedButton": "Установлено",
     "notInstalled": "Не скачана",
     "download": "Скачать",
-    "sizeMb": "{{size}} МБ"
+    "sizeMb": "{{size}} МБ",
+    "filter": {
+      "all": "Все",
+      "STT": "Whisper",
+      "LLM": "LLM",
+      "VAD": "VAD",
+      "AUDIO_ML": "Embedding",
+      "NLP_ML": "NLP"
+    }
   },
   "obsidian": {
     "title": "Obsidian vault",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -115,6 +115,7 @@
     "resumedFrom": "Возобновлено с {{time}}",
     "status": {
       "Queued": "В очереди",
+      "PreflightChecks": "Предпроверка",
       "Transcribing": "Транскрибация",
       "Correcting": "Коррекция",
       "Summarizing": "LLM-суммаризация",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -91,6 +91,18 @@
     "liveTranscriptLabel": "Идёт расшифровка",
     "liveTranscriptWaiting": "Слушаю микрофон…"
   },
+  "recording": {
+    "listening": "Слушаю микрофон…",
+    "processing": {
+      "transcribing": "Превращаю в текст…",
+      "correcting": "Исправляю опечатки…",
+      "llmCleanup": "Уточняю через LLM…",
+      "summarizing": "Готовлю summary…",
+      "exporting": "Сохраняю в Obsidian…",
+      "paused": "На паузе",
+      "failed": "Не получилось — {{step}}"
+    }
+  },
   "dashboard": {
     "title": "Дашборд",
     "importTitle": "Добавить запись",

--- a/schema.graphql
+++ b/schema.graphql
@@ -1184,6 +1184,7 @@ enum JobStatus {
   DONE
   FAILED
   CANCELLED
+  PREFLIGHT_CHECKS
 }
 
 enum ModelKind {

--- a/scripts/demo.command
+++ b/scripts/demo.command
@@ -119,9 +119,9 @@ echo "→ starting backend (dotnet)..."
 (cd backend && dotnet run --project src/Mozgoslav.Api -c Release --no-launch-profile) &
 BACKEND_PID=$!
 
-# Wait for backend /api/health
+# Wait for backend /health
 for i in {1..30}; do
-  if curl -sf http://localhost:5050/api/health >/dev/null 2>&1; then
+  if curl -sf http://localhost:5050/health >/dev/null 2>&1; then
     echo "  ✓ backend up"
     break
   fi

--- a/searxng-sidecar/launch.sh
+++ b/searxng-sidecar/launch.sh
@@ -13,10 +13,16 @@ if [ ! -f "$USER_SETTINGS" ]; then
 fi
 
 VENV_DIR="$SCRIPT_DIR/.venv"
+HASH_FILE="$VENV_DIR/.installed-hash"
+REQUIREMENTS="$SCRIPT_DIR/requirements.txt"
 
-if [ ! -d "$VENV_DIR" ]; then
+current_hash="$(sha256sum "$REQUIREMENTS" | awk '{print $1}')"
+
+if [ ! -d "$VENV_DIR" ] || [ ! -f "$HASH_FILE" ] || [ "$(cat "$HASH_FILE")" != "$current_hash" ]; then
+  rm -rf "$VENV_DIR"
   python3 -m venv "$VENV_DIR"
-  "$VENV_DIR/bin/pip" install --quiet -r "$SCRIPT_DIR/requirements.txt"
+  "$VENV_DIR/bin/pip" install --quiet -r "$REQUIREMENTS"
+  echo "$current_hash" > "$HASH_FILE"
 fi
 
 SEARXNG_SETTINGS_PATH="$USER_SETTINGS" exec "$VENV_DIR/bin/python" -m searx.webapp


### PR DESCRIPTION
- Closes #235 — fix(tooling): demo.command health endpoint
- Closes #237 — fix(searxng): venv auto-recreate on requirements drift
- Closes #236 — refactor(electron): /api/settings → GraphQL QuerySettings
- Closes #233 — fix(electron): backendLauncher attach to running :5050
- Closes #239 #231 — feat(recording): PreflightChecks stage + Whisper UserError
- Closes #249 — feat(recording): idempotent stages + resume from last completed
- Closes #253 — fix(ui): context-aware live transcript label
- Closes #238 — feat(ui): Models page type filter chips

ADR: docs/adr/ADR-EE-001-pipeline-preflight-and-resume.md