### PR TITLE
test: backend coverage cleanup — GraphQL HTTP + Infrastructure + tooling (#274 #275 #276 #277 #278)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,9 @@ jobs:
           bin_name=$(basename "$test_bundle" .xctest)
           bin_path="${test_bundle}/Contents/MacOS/${bin_name}"
           [ -f "$bin_path" ] || bin_path="${test_bundle}/${bin_name}"
-          xcrun llvm-cov export -format=lcov "$bin_path" -instr-profile "$profdata" > coverage.lcov
+          xcrun llvm-cov export -format=lcov \
+            -ignore-filename-regex='(/Applications/Xcode|/Library/Developer|/usr/lib|\.build/checkouts|/SourcePackages/)' \
+            "$bin_path" -instr-profile "$profdata" > coverage.lcov
           ls -la coverage.lcov
       - name: Upload native coverage
         if: always()

--- a/backend/IntegrationTests.runsettings
+++ b/backend/IntegrationTests.runsettings
@@ -34,6 +34,7 @@
           <Include>[Mozgoslav.Api]*,[Mozgoslav.Application]*,[Mozgoslav.Domain]*,[Mozgoslav.Infrastructure]*</Include>
           <Exclude>[Mozgoslav.Tests*]*,[Mozgoslav.Api]Program</Exclude>
           <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+          <ExcludeByFile>**/obj/**/*.cs</ExcludeByFile>
           <SingleHit>false</SingleHit>
           <UseSourceLink>true</UseSourceLink>
           <SkipAutoProps>true</SkipAutoProps>

--- a/backend/UnitTests.runsettings
+++ b/backend/UnitTests.runsettings
@@ -31,9 +31,10 @@
       <DataCollector friendlyName="XPlat code coverage" enabled="True">
         <Configuration>
           <Format>cobertura</Format>
-          <Include>[Mozgoslav.Domain]*,[Mozgoslav.Application]*,[Mozgoslav.Infrastructure]*</Include>
+          <Include>[Mozgoslav.Domain]*,[Mozgoslav.Application]*,[Mozgoslav.Infrastructure]*,[Mozgoslav.Api]*</Include>
           <Exclude>[Mozgoslav.Tests*]*</Exclude>
           <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+          <ExcludeByFile>**/obj/**/*.cs</ExcludeByFile>
           <SingleHit>false</SingleHit>
           <UseSourceLink>true</UseSourceLink>
           <SkipAutoProps>true</SkipAutoProps>

--- a/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Backup/BackupGraphQLTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Backup/BackupGraphQLTests.cs
@@ -1,0 +1,58 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+namespace Mozgoslav.Tests.Integration.Api.GraphQL.Backup;
+
+[TestClass]
+public sealed class BackupGraphQLTests : IntegrationTestsBase
+{
+    [TestMethod]
+    public async Task BackupsQuery_ReturnsArray()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  backups { name path sizeBytes createdAt }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        json["data"]!["backups"].Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task CreateBackupMutation_ReturnsPayload()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  createBackup {
+                    backup { name path sizeBytes }
+                    errors { code message }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        var payload = json["data"]!["createBackup"];
+        payload.Should().NotBeNull();
+    }
+}

--- a/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Dictation/DictationGraphQLTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Dictation/DictationGraphQLTests.cs
@@ -1,0 +1,110 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+namespace Mozgoslav.Tests.Integration.Api.GraphQL.Dictation;
+
+[TestClass]
+public sealed class DictationGraphQLTests : IntegrationTestsBase
+{
+    [TestMethod]
+    public async Task DictationAudioCapabilitiesQuery_ReturnsShape()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  dictationAudioCapabilities { isSupported detectedPlatform permissionsRequired }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        var caps = json["data"]!["dictationAudioCapabilities"];
+        caps.Should().NotBeNull();
+        caps!["isSupported"].Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task DictationStatusQuery_UnknownSession_ReturnsNull()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  dictationStatus(sessionId: "00000000-0000-0000-0000-000000000001") {
+                    sessionId state source
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        json["data"]!["dictationStatus"].Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task DictationStartMutation_ReturnsSessionId()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  dictationStart(source: "test-integration") {
+                    sessionId source errors { code message }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        var payload = json["data"]!["dictationStart"];
+        payload.Should().NotBeNull();
+        var errors = payload!["errors"]!.AsArray();
+        errors.Count.Should().Be(0);
+        payload["sessionId"].Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task DictationStopMutation_UnknownSession_ReturnsNotFoundError()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  dictationStop(sessionId: "00000000-0000-0000-0000-000000000099") {
+                    rawText errors { code message }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        var errors = json["data"]!["dictationStop"]!["errors"]!.AsArray();
+        errors.Count.Should().BeGreaterThan(0);
+        errors[0]!["code"]!.GetValue<string>().Should().Be("NOT_FOUND");
+    }
+}

--- a/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Health/HealthGraphQLTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Health/HealthGraphQLTests.cs
@@ -1,0 +1,78 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+namespace Mozgoslav.Tests.Integration.Api.GraphQL.Health;
+
+[TestClass]
+public sealed class HealthGraphQLTests : IntegrationTestsBase
+{
+    [TestMethod]
+    public async Task HealthQuery_ReturnsOk()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  health { status time }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        json["data"]!["health"]!["status"]!.GetValue<string>().Should().Be("ok");
+        json["data"]!["health"]!["time"].Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task MetaQuery_ReturnsVersionShape()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  meta { version assemblyVersion commit buildDate }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        var meta = json["data"]!["meta"];
+        meta.Should().NotBeNull();
+        meta!["version"].Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task LlmHealthQuery_ReturnsShape()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  llmHealth { available }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        json["data"]!["llmHealth"]!["available"].Should().NotBeNull();
+    }
+}

--- a/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Jobs/JobsGraphQLTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Jobs/JobsGraphQLTests.cs
@@ -1,0 +1,163 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+namespace Mozgoslav.Tests.Integration.Api.GraphQL.Jobs;
+
+[TestClass]
+public sealed class JobsGraphQLTests : IntegrationTestsBase
+{
+    [TestMethod]
+    public async Task JobsQuery_ReturnsPagedShape()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  jobs(first: 5) {
+                    totalCount
+                    nodes { id status createdAt }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        json["data"]!["jobs"]!["totalCount"].Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task ActiveJobsQuery_ReturnsArray()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  activeJobs { id status recordingId profileId }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        json["data"]!["activeJobs"].Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task EnqueueJobMutation_RecordingNotFound_ReturnsNotFoundError()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation($input: EnqueueJobInput!) {
+                  enqueueJob(input: $input) {
+                    job { id }
+                    errors { code message }
+                  }
+                }
+                """,
+            variables = new
+            {
+                input = new
+                {
+                    recordingId = "00000000-0000-0000-0000-000000000001",
+                    profileId = "00000000-0000-0000-0000-000000000002"
+                }
+            }
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var errors = json["data"]!["enqueueJob"]!["errors"]!.AsArray();
+        errors.Count.Should().BeGreaterThan(0);
+        errors[0]!["code"]!.GetValue<string>().Should().Be("NOT_FOUND");
+    }
+
+    [TestMethod]
+    public async Task CancelJobMutation_NotFound_ReturnsNotFoundError()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  cancelJob(id: "00000000-0000-0000-0000-000000000003") {
+                    errors { code message }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var errors = json["data"]!["cancelJob"]!["errors"]!.AsArray();
+        errors.Count.Should().BeGreaterThan(0);
+        errors[0]!["code"]!.GetValue<string>().Should().Be("NOT_FOUND");
+    }
+
+    [TestMethod]
+    public async Task PauseJobMutation_NotFound_ReturnsNotFoundError()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  pauseJob(id: "00000000-0000-0000-0000-000000000004") {
+                    errors { code message }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var errors = json["data"]!["pauseJob"]!["errors"]!.AsArray();
+        errors.Count.Should().BeGreaterThan(0);
+        errors[0]!["code"]!.GetValue<string>().Should().Be("NOT_FOUND");
+    }
+
+    [TestMethod]
+    public async Task ResumeJobMutation_NotFound_ReturnsNotFoundError()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  resumeJob(id: "00000000-0000-0000-0000-000000000005") {
+                    job { id }
+                    errors { code message }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var errors = json["data"]!["resumeJob"]!["errors"]!.AsArray();
+        errors.Count.Should().BeGreaterThan(0);
+        errors[0]!["code"]!.GetValue<string>().Should().Be("NOT_FOUND");
+    }
+}

--- a/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Meetily/MeetilyGraphQLTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Meetily/MeetilyGraphQLTests.cs
@@ -1,0 +1,64 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+namespace Mozgoslav.Tests.Integration.Api.GraphQL.Meetily;
+
+[TestClass]
+public sealed class MeetilyGraphQLTests : IntegrationTestsBase
+{
+    [TestMethod]
+    public async Task ImportFromMeetilyMutation_EmptyPath_ReturnsValidationError()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  importFromMeetily(meetilyDatabasePath: "") {
+                    totalMeetings importedRecordings skippedDuplicates
+                    errors { code message }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        var errors = json["data"]!["importFromMeetily"]!["errors"]!.AsArray();
+        errors.Count.Should().BeGreaterThan(0);
+        errors[0]!["code"]!.GetValue<string>().Should().Be("VALIDATION");
+    }
+
+    [TestMethod]
+    public async Task ImportFromMeetilyMutation_NonExistentPath_ReturnsNotFoundError()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  importFromMeetily(meetilyDatabasePath: "/nonexistent/path/to/meetily.db") {
+                    totalMeetings importedRecordings
+                    errors { code message }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        var errors = json["data"]!["importFromMeetily"]!["errors"]!.AsArray();
+        errors.Count.Should().BeGreaterThan(0);
+        errors[0]!["code"]!.GetValue<string>().Should().Be("NOT_FOUND");
+    }
+}

--- a/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Models/ModelsGraphQLTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Models/ModelsGraphQLTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+namespace Mozgoslav.Tests.Integration.Api.GraphQL.Models;
+
+[TestClass]
+public sealed class ModelsGraphQLTests : IntegrationTestsBase
+{
+    [TestMethod]
+    public async Task ModelsQuery_ReturnsShape()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  models { id name description sizeMb kind tier isDefault installed }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        json["data"]!["models"].Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task DownloadModelMutation_UnknownCatalogueId_ReturnsNotFoundError()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  downloadModel(catalogueId: "nonexistent-model-xyz") {
+                    downloadId
+                    errors { code message }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var errors = json["data"]!["downloadModel"]!["errors"]!.AsArray();
+        errors.Count.Should().BeGreaterThan(0);
+        errors[0]!["code"]!.GetValue<string>().Should().Be("NOT_FOUND");
+    }
+
+    [TestMethod]
+    public async Task DownloadModelMutation_EmptyCatalogueId_ReturnsValidationError()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  downloadModel(catalogueId: "") {
+                    downloadId
+                    errors { code message }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var errors = json["data"]!["downloadModel"]!["errors"]!.AsArray();
+        errors.Count.Should().BeGreaterThan(0);
+        errors[0]!["code"]!.GetValue<string>().Should().Be("VALIDATION_ERROR");
+    }
+}

--- a/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Notes/NotesGraphQLTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Notes/NotesGraphQLTests.cs
@@ -1,0 +1,115 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+namespace Mozgoslav.Tests.Integration.Api.GraphQL.Notes;
+
+[TestClass]
+public sealed class NotesGraphQLTests : IntegrationTestsBase
+{
+    [TestMethod]
+    public async Task CreateNoteMutation_ValidInput_ReturnsNote()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation($input: CreateNoteInput!) {
+                  createNote(input: $input) {
+                    note { id title markdownContent }
+                    errors { code message }
+                  }
+                }
+                """,
+            variables = new { input = new { title = "Test Note", body = "Test body content" } }
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        var errors = json["data"]!["createNote"]!["errors"]!.AsArray();
+        errors.Count.Should().Be(0);
+        json["data"]!["createNote"]!["note"]!["title"]!.GetValue<string>().Should().Be("Test Note");
+    }
+
+    [TestMethod]
+    public async Task CreateNoteMutation_EmptyTitle_ReturnsValidationError()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation($input: CreateNoteInput!) {
+                  createNote(input: $input) {
+                    note { id }
+                    errors { code message }
+                  }
+                }
+                """,
+            variables = new { input = new { title = "" } }
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var errors = json["data"]!["createNote"]!["errors"]!.AsArray();
+        errors.Count.Should().BeGreaterThan(0);
+        errors[0]!["code"]!.GetValue<string>().Should().Be("VALIDATION_ERROR");
+    }
+
+    [TestMethod]
+    public async Task DeleteNoteMutation_NotFound_ReturnsNotFoundError()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  deleteNote(id: "00000000-0000-0000-0000-000000000001") {
+                    note { id }
+                    errors { code message }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var errors = json["data"]!["deleteNote"]!["errors"]!.AsArray();
+        errors.Count.Should().BeGreaterThan(0);
+        errors[0]!["code"]!.GetValue<string>().Should().Be("NOT_FOUND");
+    }
+
+    [TestMethod]
+    public async Task ExportNoteMutation_NotFound_ReturnsNotFoundError()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  exportNote(id: "00000000-0000-0000-0000-000000000002") {
+                    note { id }
+                    errors { code message }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var errors = json["data"]!["exportNote"]!["errors"]!.AsArray();
+        errors.Count.Should().BeGreaterThan(0);
+        errors[0]!["code"]!.GetValue<string>().Should().Be("NOT_FOUND");
+    }
+}

--- a/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Obsidian/ObsidianGraphQLTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Obsidian/ObsidianGraphQLTests.cs
@@ -1,0 +1,39 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+namespace Mozgoslav.Tests.Integration.Api.GraphQL.Obsidian;
+
+[TestClass]
+public sealed class ObsidianGraphQLTests : IntegrationTestsBase
+{
+    [TestMethod]
+    public async Task ObsidianDetectQuery_ReturnsShape()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  obsidianDetect {
+                    detected { path name }
+                    searched
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        var result = json["data"]!["obsidianDetect"];
+        result.Should().NotBeNull();
+        result!["detected"].Should().NotBeNull();
+        result["searched"].Should().NotBeNull();
+    }
+}

--- a/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Profiles/ProfilesGraphQLTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Profiles/ProfilesGraphQLTests.cs
@@ -1,0 +1,140 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+namespace Mozgoslav.Tests.Integration.Api.GraphQL.Profiles;
+
+[TestClass]
+public sealed class ProfilesGraphQLTests : IntegrationTestsBase
+{
+    [TestMethod]
+    public async Task ProfilesQuery_ReturnsArray()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  profiles { id name isDefault isBuiltIn }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        json["data"]!["profiles"].Should().NotBeNull();
+        json["data"]!["profiles"]!.AsArray().Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task CreateProfileMutation_ValidInput_ReturnsProfile()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation($input: CreateProfileInput!) {
+                  createProfile(input: $input) {
+                    profile { id name isDefault }
+                    errors { code message }
+                  }
+                }
+                """,
+            variables = new
+            {
+                input = new
+                {
+                    name = "Integration Test Profile",
+                    systemPrompt = "You are a test assistant.",
+                    outputTemplate = "",
+                    cleanupLevel = "NONE",
+                    exportFolder = "_inbox",
+                    autoTags = System.Array.Empty<string>(),
+                    glossaryByLanguage = System.Array.Empty<object>(),
+                    llmCorrectionEnabled = false,
+                    isDefault = false
+                }
+            }
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        var errors = json["data"]!["createProfile"]!["errors"]!.AsArray();
+        errors.Count.Should().Be(0);
+        json["data"]!["createProfile"]!["profile"]!["name"]!.GetValue<string>().Should().Be("Integration Test Profile");
+    }
+
+    [TestMethod]
+    public async Task CreateProfileMutation_EmptyName_ReturnsValidationError()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation($input: CreateProfileInput!) {
+                  createProfile(input: $input) {
+                    profile { id }
+                    errors { code message }
+                  }
+                }
+                """,
+            variables = new
+            {
+                input = new
+                {
+                    name = "",
+                    systemPrompt = "",
+                    outputTemplate = "",
+                    cleanupLevel = "NONE",
+                    exportFolder = "_inbox",
+                    autoTags = System.Array.Empty<string>(),
+                    glossaryByLanguage = System.Array.Empty<object>(),
+                    llmCorrectionEnabled = false,
+                    isDefault = false
+                }
+            }
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var errors = json["data"]!["createProfile"]!["errors"]!.AsArray();
+        errors.Count.Should().BeGreaterThan(0);
+        errors[0]!["code"]!.GetValue<string>().Should().Be("VALIDATION_ERROR");
+    }
+
+    [TestMethod]
+    public async Task DeleteProfileMutation_NotFound_ReturnsNotFoundError()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  deleteProfile(id: "00000000-0000-0000-0000-000000000001") {
+                    profile { id }
+                    errors { code message }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var errors = json["data"]!["deleteProfile"]!["errors"]!.AsArray();
+        errors.Count.Should().BeGreaterThan(0);
+        errors[0]!["code"]!.GetValue<string>().Should().Be("NOT_FOUND");
+    }
+}

--- a/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Prompts/PromptsGraphQLTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Prompts/PromptsGraphQLTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+namespace Mozgoslav.Tests.Integration.Api.GraphQL.Prompts;
+
+[TestClass]
+public sealed class PromptsGraphQLTests : IntegrationTestsBase
+{
+    [TestMethod]
+    public async Task PromptTemplatesQuery_ReturnsArray()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  promptTemplates { id name body createdAt }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        json["data"]!["promptTemplates"].Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task CreatePromptTemplateMutation_ValidInput_ReturnsTemplate()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  createPromptTemplate(name: "Test Template", body: "Hello {{name}}") {
+                    id name body createdAt
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        var template = json["data"]!["createPromptTemplate"];
+        template.Should().NotBeNull();
+        template!["name"]!.GetValue<string>().Should().Be("Test Template");
+        template["id"].Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task PreviewPromptQuery_ReturnsString()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  previewPrompt(templateBody: "Hello world")
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        json["data"]!["previewPrompt"].Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task DeletePromptTemplateMutation_NotFound_ReturnsFalse()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation($id: UUID!) {
+                  deletePromptTemplate(id: $id)
+                }
+                """,
+            variables = new { id = Guid.NewGuid() }
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        json["data"]!["deletePromptTemplate"]!.GetValue<bool>().Should().BeFalse();
+    }
+}

--- a/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Rag/RagGraphQLTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Rag/RagGraphQLTests.cs
@@ -1,0 +1,85 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+namespace Mozgoslav.Tests.Integration.Api.GraphQL.Rag;
+
+[TestClass]
+public sealed class RagGraphQLTests : IntegrationTestsBase
+{
+    [TestMethod]
+    public async Task RagStatusQuery_ReturnsShape()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  ragStatus { embeddedNotes chunks }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        var status = json["data"]!["ragStatus"];
+        status.Should().NotBeNull();
+        status!["embeddedNotes"].Should().NotBeNull();
+        status["chunks"].Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task RagQueryQuery_EmptyQuestion_ReturnsNull()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  ragQuery(question: "") {
+                    answer llmAvailable
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        json["data"]!["ragQuery"].Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task RagReindexMutation_EmptyDatabase_ReturnsZeroCounts()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  ragReindex {
+                    embeddedNotes chunks errors { code message }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        var payload = json["data"]!["ragReindex"];
+        payload.Should().NotBeNull();
+        var errors = payload!["errors"]!.AsArray();
+        errors.Count.Should().Be(0);
+    }
+}

--- a/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Recordings/RecordingsGraphQLTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Recordings/RecordingsGraphQLTests.cs
@@ -1,0 +1,138 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+namespace Mozgoslav.Tests.Integration.Api.GraphQL.Recordings;
+
+[TestClass]
+public sealed class RecordingsGraphQLTests : IntegrationTestsBase
+{
+    [TestMethod]
+    public async Task RecordingsQuery_ReturnsPagedShape()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  recordings(first: 5) {
+                    totalCount
+                    nodes { id fileName status createdAt }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        json["data"]!["recordings"]!["totalCount"].Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task RecordingQuery_NotFound_ReturnsNull()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  recording(id: "00000000-0000-0000-0000-000000000001") {
+                    id fileName status
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        json["data"]!["recording"].Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task ImportRecordingsMutation_EmptyFilePaths_ReturnsValidationError()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation($input: ImportRecordingsInput!) {
+                  importRecordings(input: $input) {
+                    recordings { id }
+                    errors { code message }
+                  }
+                }
+                """,
+            variables = new { input = new { filePaths = System.Array.Empty<string>() } }
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var errors = json["data"]!["importRecordings"]!["errors"]!.AsArray();
+        errors.Count.Should().BeGreaterThan(0);
+        errors[0]!["code"]!.GetValue<string>().Should().Be("VALIDATION_ERROR");
+    }
+
+    [TestMethod]
+    public async Task DeleteRecordingMutation_NotFound_ReturnsNotFoundError()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  deleteRecording(id: "00000000-0000-0000-0000-000000000002") {
+                    recording { id }
+                    errors { code message }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var errors = json["data"]!["deleteRecording"]!["errors"]!.AsArray();
+        errors.Count.Should().BeGreaterThan(0);
+        errors[0]!["code"]!.GetValue<string>().Should().Be("NOT_FOUND");
+    }
+
+    [TestMethod]
+    public async Task ReprocessRecordingMutation_NotFound_ReturnsNotFoundError()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  reprocessRecording(
+                    recordingId: "00000000-0000-0000-0000-000000000003"
+                    profileId: "00000000-0000-0000-0000-000000000004"
+                  ) {
+                    recording { id }
+                    errors { code message }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var errors = json["data"]!["reprocessRecording"]!["errors"]!.AsArray();
+        errors.Count.Should().BeGreaterThan(0);
+        errors[0]!["code"]!.GetValue<string>().Should().Be("NOT_FOUND");
+    }
+}

--- a/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Routines/RoutinesGraphQLTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Routines/RoutinesGraphQLTests.cs
@@ -29,7 +29,7 @@ public sealed class RoutinesGraphQLTests : IntegrationTestsBase
         var rawBody = await response.Content.ReadAsStringAsync();
         var json = JsonNode.Parse(rawBody);
         json.Should().NotBeNull();
-        (json!["data"] is not null || json["errors"] is not null).Should().BeTrue();
+        (json["data"] is not null || json["errors"] is not null).Should().BeTrue();
     }
 
     [TestMethod]
@@ -77,6 +77,6 @@ public sealed class RoutinesGraphQLTests : IntegrationTestsBase
         var rawBody = await response.Content.ReadAsStringAsync();
         var json = JsonNode.Parse(rawBody);
         json.Should().NotBeNull();
-        (json!["data"] is not null || json["errors"] is not null).Should().BeTrue();
+        (json["data"] is not null || json["errors"] is not null).Should().BeTrue();
     }
 }

--- a/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Routines/RoutinesGraphQLTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Routines/RoutinesGraphQLTests.cs
@@ -1,0 +1,82 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+namespace Mozgoslav.Tests.Integration.Api.GraphQL.Routines;
+
+[TestClass]
+public sealed class RoutinesGraphQLTests : IntegrationTestsBase
+{
+    [TestMethod]
+    public async Task RoutinesQuery_ReturnsHttpOk()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  routines { key displayName description isEnabled }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var rawBody = await response.Content.ReadAsStringAsync();
+        var json = JsonNode.Parse(rawBody);
+        json.Should().NotBeNull();
+        (json!["data"] is not null || json["errors"] is not null).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task ToggleRoutineMutation_UnknownKey_ThrowsOrReturns()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  toggleRoutine(key: "nonexistent-routine-key-xyz", enabled: false) {
+                    key displayName isEnabled
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var hasErrors = json["errors"] is not null;
+        var hasData = json["data"]?["toggleRoutine"] is not null;
+        (hasErrors || hasData || json["data"]?["toggleRoutine"] is null).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task RoutineRunsQuery_ReturnsHttpOk()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  routineRuns(key: "nonexistent-key", limit: 10) {
+                    id routineKey status
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var rawBody = await response.Content.ReadAsStringAsync();
+        var json = JsonNode.Parse(rawBody);
+        json.Should().NotBeNull();
+        (json!["data"] is not null || json["errors"] is not null).Should().BeTrue();
+    }
+}

--- a/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Search/SearchGraphQLTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Search/SearchGraphQLTests.cs
@@ -1,0 +1,37 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+namespace Mozgoslav.Tests.Integration.Api.GraphQL.Search;
+
+[TestClass]
+public sealed class SearchGraphQLTests : IntegrationTestsBase
+{
+    [TestMethod]
+    public async Task UnifiedSearchQuery_ReturnsShape()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  unifiedSearch(query: "test query", includeWeb: false) {
+                    answer
+                    citations { source reference snippet }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var payload = json["data"]!["unifiedSearch"];
+        payload.Should().NotBeNull();
+        payload!["citations"].Should().NotBeNull();
+    }
+}

--- a/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Settings/SettingsGraphQLTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Settings/SettingsGraphQLTests.cs
@@ -1,0 +1,121 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+namespace Mozgoslav.Tests.Integration.Api.GraphQL.Settings;
+
+[TestClass]
+public sealed class SettingsGraphQLTests : IntegrationTestsBase
+{
+    [TestMethod]
+    public async Task SettingsQuery_ReturnsShape()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  settings {
+                    vaultPath llmProvider llmEndpoint llmModel language themeMode
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["data"]!["settings"].Should().NotBeNull();
+        json["data"]!["settings"]!["vaultPath"].Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task UpdateSettingsMutation_ValidInput_ReturnsSavedSettings()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation($input: UpdateSettingsInput!) {
+                  updateSettings(input: $input) {
+                    settings { vaultPath llmProvider llmModel language }
+                    errors { code message }
+                  }
+                }
+                """,
+            variables = new
+            {
+                input = new
+                {
+                    vaultPath = "/tmp/vault",
+                    llmProvider = "openai",
+                    llmEndpoint = "http://localhost:11434",
+                    llmModel = "gpt-4",
+                    llmApiKey = "",
+                    obsidianApiHost = "",
+                    obsidianApiToken = "",
+                    whisperModelPath = "",
+                    vadModelPath = "",
+                    language = "en",
+                    themeMode = "dark",
+                    whisperThreads = 4,
+                    dictationEnabled = false,
+                    dictationHotkeyType = "keyboard",
+                    dictationMouseButton = 0,
+                    dictationKeyboardHotkey = "",
+                    dictationLanguage = "en",
+                    dictationWhisperModelId = "",
+                    dictationCaptureSampleRate = 16000,
+                    dictationLlmPolish = false,
+                    dictationInjectMode = "clipboard",
+                    dictationOverlayEnabled = false,
+                    dictationOverlayPosition = "bottom-right",
+                    dictationSoundFeedback = false,
+                    dictationVocabulary = System.Array.Empty<string>(),
+                    dictationModelUnloadMinutes = 5,
+                    dictationTempAudioPath = "",
+                    dictationAppProfiles = System.Array.Empty<object>(),
+                    syncthingEnabled = false,
+                    syncthingObsidianVaultPath = "",
+                    syncthingApiKey = "",
+                    syncthingBaseUrl = ""
+                }
+            }
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var errors = json["errors"];
+        errors.Should().BeNull();
+        var settings = json["data"]!["updateSettings"]!["settings"];
+        settings.Should().NotBeNull();
+        settings!["vaultPath"]!.GetValue<string>().Should().Be("/tmp/vault");
+    }
+
+    [TestMethod]
+    public async Task LlmModelsQuery_ReturnsArray()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  llmModels { id ownedBy contextLength }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["data"]!["llmModels"].Should().NotBeNull();
+        json["data"]!["llmModels"]!.AsArray().Should().NotBeNull();
+    }
+}

--- a/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Sync/SyncGraphQLTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/Sync/SyncGraphQLTests.cs
@@ -1,0 +1,107 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+namespace Mozgoslav.Tests.Integration.Api.GraphQL.Sync;
+
+[TestClass]
+public sealed class SyncGraphQLTests : IntegrationTestsBase
+{
+    [TestMethod]
+    public async Task SyncHealthQuery_ReturnsBool()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  syncHealth
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        json["data"]!["syncHealth"].Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task SyncStatusQuery_WhenSyncthingUnavailable_ReturnsNull()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  syncStatus {
+                    folders { id state }
+                    devices { id name connected }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task AcceptSyncDeviceMutation_EmptyDeviceId_ReturnsValidationError()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  acceptSyncDevice(deviceId: "") {
+                    accepted
+                    errors { code message }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        var errors = json["data"]!["acceptSyncDevice"]!["errors"]!.AsArray();
+        errors.Count.Should().BeGreaterThan(0);
+        errors[0]!["code"]!.GetValue<string>().Should().Be("VALIDATION");
+    }
+
+    [TestMethod]
+    public async Task AcceptSyncDeviceMutation_NonEmptyDeviceId_ReturnsPayload()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation {
+                  acceptSyncDevice(deviceId: "DEVICE-ID-XXXX-YYYY") {
+                    accepted
+                    errors { code message }
+                  }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        json["data"]!["acceptSyncDevice"].Should().NotBeNull();
+        json["data"]!["acceptSyncDevice"]!["accepted"].Should().NotBeNull();
+    }
+}

--- a/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/SystemActions/SystemActionsGraphQLTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/SystemActions/SystemActionsGraphQLTests.cs
@@ -1,0 +1,34 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+namespace Mozgoslav.Tests.Integration.Api.GraphQL.SystemActions;
+
+[TestClass]
+public sealed class SystemActionsGraphQLTests : IntegrationTestsBase
+{
+    [TestMethod]
+    public async Task SystemActionTemplatesQuery_ReturnsArray()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  systemActionTemplates { name description deeplinkUrl }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        json["data"]!["systemActionTemplates"].Should().NotBeNull();
+        json["data"]!["systemActionTemplates"]!.AsArray().Should().NotBeNull();
+    }
+}

--- a/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/WebSearch/WebSearchGraphQLTests.cs
+++ b/backend/tests/Mozgoslav.Tests.Integration/Api/GraphQL/WebSearch/WebSearchGraphQLTests.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+namespace Mozgoslav.Tests.Integration.Api.GraphQL.WebSearch;
+
+[TestClass]
+public sealed class WebSearchGraphQLTests : IntegrationTestsBase
+{
+    [TestMethod]
+    public async Task WebSearchConfigQuery_ReturnsShape()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                query {
+                  webSearchConfig { ddgEnabled yandexEnabled googleEnabled cacheTtlHours }
+                }
+                """
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        var config = json["data"]!["webSearchConfig"];
+        config.Should().NotBeNull();
+        config!["ddgEnabled"].Should().NotBeNull();
+        config["cacheTtlHours"].Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task UpdateWebSearchConfigMutation_ValidInput_ReturnsUpdatedConfig()
+    {
+        using var client = CreateClient();
+        var body = new
+        {
+            query = """
+                mutation($input: WebSearchConfigInput!) {
+                  updateWebSearchConfig(input: $input) {
+                    config { ddgEnabled yandexEnabled googleEnabled cacheTtlHours }
+                    errors { code message }
+                  }
+                }
+                """,
+            variables = new
+            {
+                input = new
+                {
+                    ddgEnabled = true,
+                    yandexEnabled = false,
+                    googleEnabled = false,
+                    cacheTtlHours = 12
+                }
+            }
+        };
+
+        using var response = await client.PostAsJsonAsync("/graphql", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        json["errors"].Should().BeNull();
+        var payload = json["data"]!["updateWebSearchConfig"];
+        payload.Should().NotBeNull();
+        var errors = payload!["errors"]!.AsArray();
+        errors.Count.Should().Be(0);
+    }
+}

--- a/backend/tests/Mozgoslav.Tests/Infrastructure/Jobs/WeeklyAggregatedSummaryJobTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Infrastructure/Jobs/WeeklyAggregatedSummaryJobTests.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Mozgoslav.Application.Interfaces;
+using Mozgoslav.Application.Obsidian;
+using Mozgoslav.Application.UseCases;
+using Mozgoslav.Infrastructure.Jobs;
+
+using NSubstitute;
+
+using Quartz;
+
+namespace Mozgoslav.Tests.Infrastructure.Jobs;
+
+[TestClass]
+public sealed class WeeklyAggregatedSummaryJobTests
+{
+    private static IJobExecutionContext MakeContext(CancellationToken ct = default)
+    {
+        var ctx = Substitute.For<IJobExecutionContext>();
+        ctx.CancellationToken.Returns(ct);
+        return ctx;
+    }
+
+    private sealed class Fixture : IAsyncDisposable
+    {
+        public IProcessedNoteRepository Notes { get; } = Substitute.For<IProcessedNoteRepository>();
+        public ILlmService Llm { get; } = Substitute.For<ILlmService>();
+        public IVaultDriver Vault { get; } = Substitute.For<IVaultDriver>();
+        public IAppSettings Settings { get; } = Substitute.For<IAppSettings>();
+
+        private readonly ServiceProvider _provider;
+
+        public Fixture()
+        {
+            Notes.GetByDateRangeAsync(Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+                .Returns([]);
+            Llm.IsAvailableAsync(Arg.Any<CancellationToken>()).Returns(false);
+            Settings.VaultPath.Returns("/tmp/test-vault");
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddSingleton(Notes);
+            services.AddSingleton(Llm);
+            services.AddSingleton(Vault);
+            services.AddSingleton(Settings);
+            services.AddScoped<AggregateSummaryUseCase>();
+            _provider = services.BuildServiceProvider();
+        }
+
+        public WeeklyAggregatedSummaryJob BuildJob() =>
+            new(_provider.GetRequiredService<IServiceScopeFactory>(),
+                NullLogger<WeeklyAggregatedSummaryJob>.Instance);
+
+        public async ValueTask DisposeAsync()
+        {
+            await _provider.DisposeAsync();
+        }
+    }
+
+    [TestMethod]
+    public async Task Execute_NullContext_ThrowsArgumentNullException()
+    {
+        await using var fixture = new Fixture();
+        var job = fixture.BuildJob();
+
+        var act = async () => await job.Execute(null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [TestMethod]
+    public async Task Execute_NoNotesInPeriod_DoesNotWriteToVault()
+    {
+        await using var fixture = new Fixture();
+        fixture.Notes.GetByDateRangeAsync(Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var job = fixture.BuildJob();
+        await job.Execute(MakeContext());
+
+        await fixture.Vault.DidNotReceiveWithAnyArgs().WriteNoteAsync(default!, default);
+    }
+
+    [TestMethod]
+    public async Task Execute_WithNotes_WritesAggregatedSummaryToVault()
+    {
+        await using var fixture = new Fixture();
+
+        var note = new Mozgoslav.Domain.Entities.ProcessedNote
+        {
+            MarkdownContent = "Weekly meeting notes",
+            CreatedAt = DateTime.UtcNow
+        };
+
+        fixture.Notes.GetByDateRangeAsync(Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns([note]);
+        fixture.Vault.EnsureFolderAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        fixture.Vault.WriteNoteAsync(Arg.Any<VaultNoteWrite>(), Arg.Any<CancellationToken>())
+            .Returns(new VaultWriteReceipt("aggregated/x.md", "abc", 10L, VaultWriteAction.Created));
+
+        var job = fixture.BuildJob();
+        await job.Execute(MakeContext());
+
+        await fixture.Vault.Received(1).WriteNoteAsync(
+            Arg.Is<VaultNoteWrite>(w => w.VaultRelativePath.StartsWith("aggregated/")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [TestMethod]
+    public async Task Execute_VaultPathBlank_SkipsWithoutException()
+    {
+        await using var fixture = new Fixture();
+        fixture.Settings.VaultPath.Returns(string.Empty);
+        fixture.Notes.GetByDateRangeAsync(Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns([new Mozgoslav.Domain.Entities.ProcessedNote { MarkdownContent = "x" }]);
+
+        var job = fixture.BuildJob();
+        var act = async () => await job.Execute(MakeContext());
+
+        await act.Should().NotThrowAsync();
+        await fixture.Vault.DidNotReceiveWithAnyArgs().WriteNoteAsync(default!, default);
+    }
+
+    [TestMethod]
+    public async Task Execute_PeriodLabelContainsWeeklyLabel()
+    {
+        await using var fixture = new Fixture();
+
+        string? capturedPath = null;
+        fixture.Notes.GetByDateRangeAsync(Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns([new Mozgoslav.Domain.Entities.ProcessedNote { MarkdownContent = "note" }]);
+        fixture.Vault.EnsureFolderAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        fixture.Vault.WriteNoteAsync(Arg.Any<VaultNoteWrite>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                capturedPath = ci.ArgAt<VaultNoteWrite>(0).VaultRelativePath;
+                return new VaultWriteReceipt(capturedPath ?? string.Empty, "abc", 5L, VaultWriteAction.Created);
+            });
+
+        var job = fixture.BuildJob();
+        await job.Execute(MakeContext());
+
+        var now = DateTimeOffset.UtcNow;
+        var dayOfWeek = (int)now.DayOfWeek;
+        var daysToMonday = dayOfWeek == 0 ? 6 : dayOfWeek - 1;
+        var weekStart = now.AddDays(-daysToMonday).Date;
+        var isoWeek = ISOWeek.GetWeekOfYear(weekStart);
+        var isoYear = ISOWeek.GetYear(weekStart);
+        var expectedLabel = $"weekly-{isoYear:D4}-W{isoWeek:D2}";
+
+        capturedPath.Should().Contain(expectedLabel);
+    }
+}

--- a/backend/tests/Mozgoslav.Tests/Infrastructure/Mcp/Tools/CorpusMcpToolsTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Infrastructure/Mcp/Tools/CorpusMcpToolsTests.cs
@@ -1,0 +1,80 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Mozgoslav.Application.Rag;
+using Mozgoslav.Infrastructure.Mcp.Tools;
+
+using NSubstitute;
+
+namespace Mozgoslav.Tests.Infrastructure.Mcp.Tools;
+
+[TestClass]
+public sealed class CorpusMcpToolsTests
+{
+    private sealed class Fixture
+    {
+        public IRagService RagService { get; } = Substitute.For<IRagService>();
+
+        public CorpusMcpTools BuildSut() => new(RagService);
+    }
+
+    [TestMethod]
+    public async Task QueryAsync_ValidQuestion_ReturnsAnswer()
+    {
+        var fixture = new Fixture();
+        NoteChunkHit[] citations =
+        [
+            new(new NoteChunk("c1", System.Guid.NewGuid(), "chunk text", []), 0.9)
+        ];
+        fixture.RagService.AnswerAsync("what is X?", 5, Arg.Any<CancellationToken>())
+            .Returns(new RagAnswer("The answer", citations, true));
+
+        var sut = fixture.BuildSut();
+        var result = await sut.QueryAsync("what is X?", 5, CancellationToken.None);
+
+        result.Answer.Should().Be("The answer");
+        result.Citations.Should().HaveCount(1);
+        result.Citations[0].Should().Be("chunk text");
+    }
+
+    [TestMethod]
+    public async Task QueryAsync_TopKBelowMin_ClampsTo1()
+    {
+        var fixture = new Fixture();
+        fixture.RagService.AnswerAsync(Arg.Any<string>(), 1, Arg.Any<CancellationToken>())
+            .Returns(new RagAnswer("ok", [], false));
+
+        var sut = fixture.BuildSut();
+        await sut.QueryAsync("q", 0, CancellationToken.None);
+
+        await fixture.RagService.Received(1).AnswerAsync("q", 1, Arg.Any<CancellationToken>());
+    }
+
+    [TestMethod]
+    public async Task QueryAsync_TopKAboveMax_ClampsTo20()
+    {
+        var fixture = new Fixture();
+        fixture.RagService.AnswerAsync(Arg.Any<string>(), 20, Arg.Any<CancellationToken>())
+            .Returns(new RagAnswer("ok", [], false));
+
+        var sut = fixture.BuildSut();
+        await sut.QueryAsync("q", 99, CancellationToken.None);
+
+        await fixture.RagService.Received(1).AnswerAsync("q", 20, Arg.Any<CancellationToken>());
+    }
+
+    [TestMethod]
+    public async Task QueryAsync_NoCitations_ReturnsEmptyArray()
+    {
+        var fixture = new Fixture();
+        fixture.RagService.AnswerAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new RagAnswer("no citations", [], false));
+
+        var sut = fixture.BuildSut();
+        var result = await sut.QueryAsync("q", 5, CancellationToken.None);
+
+        result.Citations.Should().BeEmpty();
+    }
+}

--- a/backend/tests/Mozgoslav.Tests/Infrastructure/Mcp/Tools/DictationMcpToolsTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Infrastructure/Mcp/Tools/DictationMcpToolsTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Mozgoslav.Application.Interfaces;
+using Mozgoslav.Domain.Entities;
+using Mozgoslav.Domain.ValueObjects;
+using Mozgoslav.Infrastructure.Mcp.Tools;
+
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace Mozgoslav.Tests.Infrastructure.Mcp.Tools;
+
+[TestClass]
+public sealed class DictationMcpToolsTests
+{
+    private sealed class Fixture
+    {
+        public IDictationSessionManager Manager { get; } = Substitute.For<IDictationSessionManager>();
+
+        public DictationMcpTools BuildSut() => new(Manager);
+    }
+
+    [TestMethod]
+    public void Start_ReturnsSessionId()
+    {
+        var fixture = new Fixture();
+        var session = new DictationSession { Id = Guid.NewGuid() };
+        fixture.Manager.Start(Arg.Any<string?>(), Arg.Any<Mozgoslav.Domain.Enums.DictationSessionKind>(), Arg.Any<Guid?>())
+            .Returns(session);
+        var sut = fixture.BuildSut();
+
+        var result = sut.Start();
+
+        result.SessionId.Should().Be(session.Id.ToString());
+    }
+
+    [TestMethod]
+    public async Task StopAsync_InvalidSessionId_ReturnsFailure()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var result = await sut.StopAsync("not-a-guid", CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().NotBeNullOrEmpty();
+    }
+
+    [TestMethod]
+    public async Task StopAsync_ValidSessionId_ReturnsTranscript()
+    {
+        var fixture = new Fixture();
+        var sessionId = Guid.NewGuid();
+        var final = new FinalTranscript("raw text", "polished text", TimeSpan.FromSeconds(5));
+        fixture.Manager.StopAsync(sessionId, Arg.Any<CancellationToken>(), Arg.Any<string?>())
+            .Returns(final);
+        var sut = fixture.BuildSut();
+
+        var result = await sut.StopAsync(sessionId.ToString(), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Transcript.Should().Be("polished text");
+        result.Error.Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task StopAsync_ManagerThrows_ReturnsFailure()
+    {
+        var fixture = new Fixture();
+        var sessionId = Guid.NewGuid();
+        fixture.Manager.StopAsync(sessionId, Arg.Any<CancellationToken>(), Arg.Any<string?>())
+            .ThrowsAsync(new InvalidOperationException("session not found"));
+        var sut = fixture.BuildSut();
+
+        var result = await sut.StopAsync(sessionId.ToString(), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("session not found");
+    }
+
+    [TestMethod]
+    public async Task CancelAsync_InvalidSessionId_ReturnsFailure()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var result = await sut.CancelAsync("bad-id", CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().NotBeNullOrEmpty();
+    }
+
+    [TestMethod]
+    public async Task CancelAsync_ValidSessionId_ReturnsSuccess()
+    {
+        var fixture = new Fixture();
+        var sessionId = Guid.NewGuid();
+        fixture.Manager.CancelAsync(sessionId, Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        var sut = fixture.BuildSut();
+
+        var result = await sut.CancelAsync(sessionId.ToString(), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Error.Should().BeNull();
+    }
+}

--- a/backend/tests/Mozgoslav.Tests/Infrastructure/Mcp/Tools/NotesMcpToolsTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Infrastructure/Mcp/Tools/NotesMcpToolsTests.cs
@@ -60,7 +60,7 @@ public sealed class NotesMcpToolsTests
         var result = await sut.GetAsync(id.ToString(), CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Id.Should().Be(id.ToString());
+        result.Id.Should().Be(id.ToString());
         result.Content.Should().Be("hello world");
     }
 

--- a/backend/tests/Mozgoslav.Tests/Infrastructure/Mcp/Tools/NotesMcpToolsTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Infrastructure/Mcp/Tools/NotesMcpToolsTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Mozgoslav.Application.Interfaces;
+using Mozgoslav.Domain.Entities;
+using Mozgoslav.Infrastructure.Mcp.Tools;
+
+using NSubstitute;
+
+namespace Mozgoslav.Tests.Infrastructure.Mcp.Tools;
+
+[TestClass]
+public sealed class NotesMcpToolsTests
+{
+    private sealed class Fixture
+    {
+        public IProcessedNoteRepository Notes { get; } = Substitute.For<IProcessedNoteRepository>();
+
+        public NotesMcpTools BuildSut() => new(Notes);
+    }
+
+    [TestMethod]
+    public async Task GetAsync_InvalidGuid_ReturnsNull()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var result = await sut.GetAsync("not-a-guid", CancellationToken.None);
+
+        result.Should().BeNull();
+        await fixture.Notes.DidNotReceiveWithAnyArgs().GetByIdAsync(default, default);
+    }
+
+    [TestMethod]
+    public async Task GetAsync_ValidGuid_NoteNotFound_ReturnsNull()
+    {
+        var fixture = new Fixture();
+        var id = Guid.NewGuid();
+        fixture.Notes.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((ProcessedNote?)null);
+        var sut = fixture.BuildSut();
+
+        var result = await sut.GetAsync(id.ToString(), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task GetAsync_ValidGuid_NoteFound_ReturnsMappedDto()
+    {
+        var fixture = new Fixture();
+        var id = Guid.NewGuid();
+        var note = new ProcessedNote { Id = id, MarkdownContent = "hello world", CreatedAt = DateTime.UtcNow };
+        fixture.Notes.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(note);
+        var sut = fixture.BuildSut();
+
+        var result = await sut.GetAsync(id.ToString(), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(id.ToString());
+        result.Content.Should().Be("hello world");
+    }
+
+    [TestMethod]
+    public async Task ListAsync_NoDates_ReturnsAllNotes()
+    {
+        var fixture = new Fixture();
+        var notes = new List<ProcessedNote>
+        {
+            new() { Id = Guid.NewGuid(), MarkdownContent = "a", CreatedAt = DateTime.UtcNow },
+            new() { Id = Guid.NewGuid(), MarkdownContent = "b", CreatedAt = DateTime.UtcNow.AddMinutes(-1) }
+        };
+        fixture.Notes.GetAllAsync(Arg.Any<CancellationToken>()).Returns(notes);
+        var sut = fixture.BuildSut();
+
+        var result = await sut.ListAsync(null, null, CancellationToken.None);
+
+        result.Should().HaveCount(2);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_ValidText_AddsNote()
+    {
+        var fixture = new Fixture();
+        var saved = new ProcessedNote { Id = Guid.NewGuid(), MarkdownContent = "new note" };
+        fixture.Notes.AddAsync(Arg.Any<ProcessedNote>(), Arg.Any<CancellationToken>()).Returns(saved);
+        var sut = fixture.BuildSut();
+
+        var result = await sut.CreateAsync("new note", CancellationToken.None);
+
+        result.Content.Should().Be("new note");
+        await fixture.Notes.Received(1).AddAsync(Arg.Is<ProcessedNote>(n => n.MarkdownContent == "new note"), Arg.Any<CancellationToken>());
+    }
+}

--- a/backend/tests/Mozgoslav.Tests/Infrastructure/Mcp/Tools/ObsidianMcpToolsTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Infrastructure/Mcp/Tools/ObsidianMcpToolsTests.cs
@@ -1,0 +1,91 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Mozgoslav.Application.Interfaces;
+using Mozgoslav.Application.Obsidian;
+using Mozgoslav.Infrastructure.Mcp.Tools;
+
+using NSubstitute;
+
+namespace Mozgoslav.Tests.Infrastructure.Mcp.Tools;
+
+[TestClass]
+public sealed class ObsidianMcpToolsTests
+{
+    private sealed class Fixture
+    {
+        public IVaultDriver VaultDriver { get; } = Substitute.For<IVaultDriver>();
+        public IAppSettings Settings { get; } = Substitute.For<IAppSettings>();
+
+        public ObsidianMcpTools BuildSut() => new(VaultDriver, Settings);
+    }
+
+    [TestMethod]
+    public async Task WriteAsync_CallsVaultDriver_ReturnsPath()
+    {
+        var fixture = new Fixture();
+        var receipt = new VaultWriteReceipt("_inbox/note.md", "sha256abc", 100L, VaultWriteAction.Created);
+        fixture.VaultDriver.WriteNoteAsync(Arg.Any<VaultNoteWrite>(), Arg.Any<CancellationToken>())
+            .Returns(receipt);
+        var sut = fixture.BuildSut();
+
+        var result = await sut.WriteAsync("_inbox/note.md", "# Hello", CancellationToken.None);
+
+        result.Path.Should().Be("_inbox/note.md");
+        await fixture.VaultDriver.Received(1).WriteNoteAsync(
+            Arg.Is<VaultNoteWrite>(w => w.VaultRelativePath == "_inbox/note.md" && w.Body == "# Hello"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [TestMethod]
+    public async Task ReadAsync_VaultPathBlank_ReturnsEmptyNotFound()
+    {
+        var fixture = new Fixture();
+        fixture.Settings.VaultPath.Returns(string.Empty);
+        var sut = fixture.BuildSut();
+
+        var result = await sut.ReadAsync("_inbox/note.md", CancellationToken.None);
+
+        result.Exists.Should().BeFalse();
+        result.Content.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task ReadAsync_FileDoesNotExist_ReturnsNotFound()
+    {
+        var fixture = new Fixture();
+        fixture.Settings.VaultPath.Returns(Path.GetTempPath());
+        var sut = fixture.BuildSut();
+
+        var result = await sut.ReadAsync("nonexistent-file-xyz-abc.md", CancellationToken.None);
+
+        result.Exists.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task ReadAsync_ExistingFile_ReturnsContent()
+    {
+        var fixture = new Fixture();
+        var dir = Path.Combine(Path.GetTempPath(), $"obsidian-test-{System.Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        var filePath = Path.Combine(dir, "note.md");
+        await File.WriteAllTextAsync(filePath, "# Test Content");
+        fixture.Settings.VaultPath.Returns(dir);
+        var sut = fixture.BuildSut();
+
+        try
+        {
+            var result = await sut.ReadAsync("note.md", CancellationToken.None);
+
+            result.Exists.Should().BeTrue();
+            result.Content.Should().Be("# Test Content");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/backend/tests/Mozgoslav.Tests/Infrastructure/Mcp/Tools/RecordingsMcpToolsTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Infrastructure/Mcp/Tools/RecordingsMcpToolsTests.cs
@@ -48,7 +48,7 @@ public sealed class RecordingsMcpToolsTests
         var result = await sut.SearchAsync(null, null, CancellationToken.None);
 
         result.Should().HaveCount(2);
-        string.Compare(result[0].CreatedAt, result[1].CreatedAt, System.StringComparison.Ordinal).Should().BeGreaterThanOrEqualTo(0);
+        string.Compare(result[0].CreatedAt, result[1].CreatedAt, StringComparison.Ordinal).Should().BeGreaterThanOrEqualTo(0);
     }
 
     [TestMethod]

--- a/backend/tests/Mozgoslav.Tests/Infrastructure/Mcp/Tools/RecordingsMcpToolsTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Infrastructure/Mcp/Tools/RecordingsMcpToolsTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Mozgoslav.Application.Interfaces;
+using Mozgoslav.Domain.Entities;
+using Mozgoslav.Domain.Enums;
+using Mozgoslav.Infrastructure.Mcp.Tools;
+
+using NSubstitute;
+
+namespace Mozgoslav.Tests.Infrastructure.Mcp.Tools;
+
+[TestClass]
+public sealed class RecordingsMcpToolsTests
+{
+    private sealed class Fixture
+    {
+        public IRecordingRepository Recordings { get; } = Substitute.For<IRecordingRepository>();
+
+        public RecordingsMcpTools BuildSut() => new(Recordings);
+    }
+
+    private static Recording MakeRecording(DateTime createdAt) => new()
+    {
+        Id = Guid.NewGuid(),
+        FileName = "test.m4a",
+        FilePath = "/tmp/test.m4a",
+        Sha256 = "abc123",
+        Format = AudioFormat.M4A,
+        SourceType = SourceType.Recorded,
+        Status = RecordingStatus.Transcribed,
+        Duration = TimeSpan.FromSeconds(120),
+        CreatedAt = createdAt
+    };
+
+    [TestMethod]
+    public async Task SearchAsync_NoFilter_ReturnsAllRecordingsOrderedByDate()
+    {
+        var fixture = new Fixture();
+        var older = MakeRecording(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        var newer = MakeRecording(new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc));
+        fixture.Recordings.GetAllAsync(Arg.Any<CancellationToken>()).Returns([older, newer]);
+        var sut = fixture.BuildSut();
+
+        var result = await sut.SearchAsync(null, null, CancellationToken.None);
+
+        result.Should().HaveCount(2);
+        string.Compare(result[0].CreatedAt, result[1].CreatedAt, System.StringComparison.Ordinal).Should().BeGreaterThanOrEqualTo(0);
+    }
+
+    [TestMethod]
+    public async Task SearchAsync_FromDateFilter_ExcludesOlderRecordings()
+    {
+        var fixture = new Fixture();
+        var old = MakeRecording(new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc));
+        var recent = MakeRecording(new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc));
+        fixture.Recordings.GetAllAsync(Arg.Any<CancellationToken>()).Returns([old, recent]);
+        var sut = fixture.BuildSut();
+
+        var result = await sut.SearchAsync("2026-01-01", null, CancellationToken.None);
+
+        result.Should().HaveCount(1);
+        result[0].FileName.Should().Be("test.m4a");
+    }
+
+    [TestMethod]
+    public async Task SearchAsync_MapsFieldsCorrectly()
+    {
+        var fixture = new Fixture();
+        var recording = MakeRecording(new DateTime(2026, 3, 15, 10, 0, 0, DateTimeKind.Utc));
+        fixture.Recordings.GetAllAsync(Arg.Any<CancellationToken>()).Returns([recording]);
+        var sut = fixture.BuildSut();
+
+        var result = await sut.SearchAsync(null, null, CancellationToken.None);
+
+        result.Should().HaveCount(1);
+        var dto = result[0];
+        dto.Id.Should().Be(recording.Id.ToString());
+        dto.FileName.Should().Be("test.m4a");
+        dto.DurationSeconds.Should().Be(120);
+        dto.Status.Should().Be(RecordingStatus.Transcribed.ToString());
+    }
+
+    [TestMethod]
+    public async Task SearchAsync_EmptyRepository_ReturnsEmpty()
+    {
+        var fixture = new Fixture();
+        fixture.Recordings.GetAllAsync(Arg.Any<CancellationToken>()).Returns([]);
+        var sut = fixture.BuildSut();
+
+        var result = await sut.SearchAsync(null, null, CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+}

--- a/backend/tests/Mozgoslav.Tests/Infrastructure/Obsidian/GitHubPluginInstallerTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Infrastructure/Obsidian/GitHubPluginInstallerTests.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Mozgoslav.Application.Obsidian;
+using Mozgoslav.Infrastructure.Obsidian;
+
+using NSubstitute;
+
+namespace Mozgoslav.Tests.Infrastructure.Obsidian;
+
+[TestClass]
+public sealed class GitHubPluginInstallerTests
+{
+    private sealed class FakeHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _statusCode;
+        private readonly byte[] _content;
+
+        public FakeHandler(HttpStatusCode statusCode, byte[] content)
+        {
+            _statusCode = statusCode;
+            _content = content;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var response = new HttpResponseMessage(_statusCode)
+            {
+                Content = new ByteArrayContent(_content)
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class HttpSetup : IDisposable
+    {
+        private readonly FakeHandler _handler;
+        public HttpClient Client { get; }
+
+        public HttpSetup(HttpStatusCode statusCode, byte[] content)
+        {
+            _handler = new FakeHandler(statusCode, content);
+            Client = new HttpClient(_handler);
+        }
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            _handler.Dispose();
+        }
+    }
+
+    private sealed class Fixture : IDisposable
+    {
+        private readonly IHttpClientFactory _httpClientFactory = Substitute.For<IHttpClientFactory>();
+        private readonly string _tempVaultPath;
+        private HttpSetup? _httpSetup;
+
+        public Fixture()
+        {
+            _tempVaultPath = Path.Combine(Path.GetTempPath(), $"vault-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(_tempVaultPath);
+        }
+
+        public string VaultPath => _tempVaultPath;
+
+        public GitHubPluginInstaller BuildSut() =>
+            new(_httpClientFactory, NullLogger<GitHubPluginInstaller>.Instance);
+
+        public void SetupDownloadResponse(byte[] content)
+        {
+            ReplaceSetup(new HttpSetup(HttpStatusCode.OK, content));
+        }
+
+        public void SetupDownloadFailure()
+        {
+            ReplaceSetup(new HttpSetup(HttpStatusCode.NotFound, []));
+        }
+
+        [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP004:Don't ignore created IDisposable",
+            Justification = "CreateClient returns a pre-existing client owned by HttpSetup, not a new disposable")]
+        private void ReplaceSetup(HttpSetup newSetup)
+        {
+            var old = _httpSetup;
+            _httpSetup = newSetup;
+            old?.Dispose();
+            _httpClientFactory.CreateClient(GitHubPluginInstaller.HttpClientName).Returns(_httpSetup.Client);
+        }
+
+        public void Dispose()
+        {
+            _httpSetup?.Dispose();
+            if (Directory.Exists(_tempVaultPath))
+            {
+                Directory.Delete(_tempVaultPath, recursive: true);
+            }
+        }
+    }
+
+    private static string Sha256Of(byte[] data)
+    {
+        var hash = SHA256.HashData(data);
+        var sb = new StringBuilder(hash.Length * 2);
+        foreach (var b in hash)
+        {
+            sb.Append(b.ToString("X2", System.Globalization.CultureInfo.InvariantCulture));
+        }
+        return sb.ToString();
+    }
+
+    private static PluginInstallSpec MakeSpec(string sha256) =>
+        new("test-plugin", "testowner", "testrepo", "v1.0.0",
+            [new PluginAssetSpec("main.js", sha256, "main.js")]);
+
+    [TestMethod]
+    public async Task InstallAsync_NullSpec_ThrowsArgumentNullException()
+    {
+        using var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var act = async () => await sut.InstallAsync(null!, fixture.VaultPath, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_BlankVaultPath_ThrowsArgumentException()
+    {
+        using var fixture = new Fixture();
+        var spec = MakeSpec("abc");
+        var sut = fixture.BuildSut();
+
+        var act = async () => await sut.InstallAsync(spec, "", CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_DownloadFails_ReturnsDownloadFailed()
+    {
+        using var fixture = new Fixture();
+        fixture.SetupDownloadFailure();
+        var spec = MakeSpec("abc123");
+        var sut = fixture.BuildSut();
+
+        var result = await sut.InstallAsync(spec, fixture.VaultPath, CancellationToken.None);
+
+        result.Status.Should().Be(PluginInstallStatus.DownloadFailed);
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_HashMismatch_ReturnsHashMismatch()
+    {
+        using var fixture = new Fixture();
+        var content = Encoding.UTF8.GetBytes("real file content");
+        fixture.SetupDownloadResponse(content);
+        var spec = MakeSpec("DEADBEEF0000000000000000000000000000000000000000000000000000FFFF");
+        var sut = fixture.BuildSut();
+
+        var result = await sut.InstallAsync(spec, fixture.VaultPath, CancellationToken.None);
+
+        result.Status.Should().Be(PluginInstallStatus.HashMismatch);
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_ValidDownload_ReturnsInstalled()
+    {
+        using var fixture = new Fixture();
+        var content = Encoding.UTF8.GetBytes("plugin content");
+        var sha256 = Sha256Of(content);
+        fixture.SetupDownloadResponse(content);
+        var spec = MakeSpec(sha256);
+        var sut = fixture.BuildSut();
+
+        var result = await sut.InstallAsync(spec, fixture.VaultPath, CancellationToken.None);
+
+        result.Status.Should().Be(PluginInstallStatus.Installed);
+        result.PluginId.Should().Be("test-plugin");
+        result.WrittenFiles.Should().NotBeEmpty();
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_AlreadyInstalledWithMatchingHash_ReturnsAlreadyInstalled()
+    {
+        using var fixture = new Fixture();
+        var content = Encoding.UTF8.GetBytes("plugin content");
+        var sha256 = Sha256Of(content);
+
+        var pluginDir = Path.Combine(fixture.VaultPath, ".obsidian", "plugins", "test-plugin");
+        Directory.CreateDirectory(pluginDir);
+        await File.WriteAllBytesAsync(Path.Combine(pluginDir, "main.js"), content);
+
+        var dotObsidian = Path.Combine(fixture.VaultPath, ".obsidian");
+        Directory.CreateDirectory(dotObsidian);
+        await File.WriteAllTextAsync(Path.Combine(dotObsidian, "community-plugins.json"), "[\"test-plugin\"]");
+
+        var spec = MakeSpec(sha256);
+        var sut = fixture.BuildSut();
+
+        var result = await sut.InstallAsync(spec, fixture.VaultPath, CancellationToken.None);
+
+        result.Status.Should().Be(PluginInstallStatus.AlreadyInstalled);
+    }
+
+    [TestMethod]
+    public async Task EnsureRemovedAsync_NonExistentPlugin_ReturnsNotInstalled()
+    {
+        using var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var result = await sut.EnsureRemovedAsync("ghost-plugin", fixture.VaultPath, CancellationToken.None);
+
+        result.Status.Should().Be(PluginInstallStatus.NotInstalled);
+    }
+
+    [TestMethod]
+    public async Task EnsureRemovedAsync_ExistingPlugin_ReturnsRemoved()
+    {
+        using var fixture = new Fixture();
+        var pluginDir = Path.Combine(fixture.VaultPath, ".obsidian", "plugins", "my-plugin");
+        Directory.CreateDirectory(pluginDir);
+        await File.WriteAllTextAsync(Path.Combine(pluginDir, "main.js"), "content");
+
+        var dotObsidian = Path.Combine(fixture.VaultPath, ".obsidian");
+        await File.WriteAllTextAsync(Path.Combine(dotObsidian, "community-plugins.json"), "[\"my-plugin\"]");
+
+        var sut = fixture.BuildSut();
+
+        var result = await sut.EnsureRemovedAsync("my-plugin", fixture.VaultPath, CancellationToken.None);
+
+        result.Status.Should().Be(PluginInstallStatus.Removed);
+        Directory.Exists(pluginDir).Should().BeFalse();
+    }
+}

--- a/backend/tests/Mozgoslav.Tests/Infrastructure/Obsidian/GitHubPluginInstallerTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Infrastructure/Obsidian/GitHubPluginInstallerTests.cs
@@ -64,16 +64,15 @@ public sealed class GitHubPluginInstallerTests
     private sealed class Fixture : IDisposable
     {
         private readonly IHttpClientFactory _httpClientFactory = Substitute.For<IHttpClientFactory>();
-        private readonly string _tempVaultPath;
         private HttpSetup? _httpSetup;
 
         public Fixture()
         {
-            _tempVaultPath = Path.Combine(Path.GetTempPath(), $"vault-test-{Guid.NewGuid():N}");
-            Directory.CreateDirectory(_tempVaultPath);
+            VaultPath = Path.Combine(Path.GetTempPath(), $"vault-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(VaultPath);
         }
 
-        public string VaultPath => _tempVaultPath;
+        public string VaultPath { get; }
 
         public GitHubPluginInstaller BuildSut() =>
             new(_httpClientFactory, NullLogger<GitHubPluginInstaller>.Instance);
@@ -101,9 +100,9 @@ public sealed class GitHubPluginInstallerTests
         public void Dispose()
         {
             _httpSetup?.Dispose();
-            if (Directory.Exists(_tempVaultPath))
+            if (Directory.Exists(VaultPath))
             {
-                Directory.Delete(_tempVaultPath, recursive: true);
+                Directory.Delete(VaultPath, recursive: true);
             }
         }
     }

--- a/backend/tests/Mozgoslav.Tests/Infrastructure/Platform/GrpcNativeHelperClientTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Infrastructure/Platform/GrpcNativeHelperClientTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Grpc.Core;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Mozgoslav.Infrastructure.Platform;
+using Mozgoslav.Native.V1;
+
+using NSubstitute;
+
+namespace Mozgoslav.Tests.Infrastructure.Platform;
+
+[TestClass]
+public sealed class GrpcNativeHelperClientTests
+{
+    private sealed class Fixture : IDisposable
+    {
+        private readonly List<AsyncUnaryCall<RunShortcutResult>> _calls = [];
+
+        public DictationHelper.DictationHelperClient GrpcClient { get; } =
+            Substitute.For<DictationHelper.DictationHelperClient>();
+
+        [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP004:Don't ignore created IDisposable",
+            Justification = "call is tracked in _calls list and disposed in Dispose()")]
+        public void SetupSuccessCall(RunShortcutResult result)
+        {
+            var call = new AsyncUnaryCall<RunShortcutResult>(
+                Task.FromResult(result),
+                Task.FromResult(new Metadata()),
+                () => Status.DefaultSuccess,
+                () => [],
+                () => { });
+            _calls.Add(call);
+            GrpcClient
+                .RunShortcutAsync(
+                    Arg.Any<RunShortcutRequest>(),
+                    Arg.Any<Metadata>(),
+                    Arg.Any<DateTime?>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(call);
+        }
+
+        [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP004:Don't ignore created IDisposable",
+            Justification = "call is tracked in _calls list and disposed in Dispose()")]
+        public void SetupFailingCall(Exception ex)
+        {
+            var tcs = new TaskCompletionSource<RunShortcutResult>();
+            tcs.SetException(ex);
+            var call = new AsyncUnaryCall<RunShortcutResult>(
+                tcs.Task,
+                Task.FromResult(new Metadata()),
+                () => new Status(StatusCode.Unavailable, ex.Message),
+                () => [],
+                () => { });
+            _calls.Add(call);
+            GrpcClient
+                .RunShortcutAsync(
+                    Arg.Any<RunShortcutRequest>(),
+                    Arg.Any<Metadata>(),
+                    Arg.Any<DateTime?>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(call);
+        }
+
+        public GrpcNativeHelperClient BuildSut() =>
+            new(GrpcClient, NullLogger<GrpcNativeHelperClient>.Instance);
+
+        public void Dispose()
+        {
+            foreach (var c in _calls) c.Dispose();
+        }
+    }
+
+    [TestMethod]
+    public async Task RunShortcutAsync_BlankName_ThrowsArgumentException()
+    {
+        using var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var act = async () => await sut.RunShortcutAsync("", "input", CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [TestMethod]
+    public async Task RunShortcutAsync_Success_ReturnsSuccessResult()
+    {
+        using var fixture = new Fixture();
+        fixture.SetupSuccessCall(new RunShortcutResult { Success = true, Stdout = "output text" });
+        var sut = fixture.BuildSut();
+
+        var result = await sut.RunShortcutAsync("My Shortcut", "data", CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Output.Should().Be("output text");
+        result.Error.Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task RunShortcutAsync_EmptyStdout_OutputIsNull()
+    {
+        using var fixture = new Fixture();
+        fixture.SetupSuccessCall(new RunShortcutResult { Success = true, Stdout = string.Empty });
+        var sut = fixture.BuildSut();
+
+        var result = await sut.RunShortcutAsync("Shortcut", string.Empty, CancellationToken.None);
+
+        result.Output.Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task RunShortcutAsync_GrpcUnavailable_ReturnsFailure()
+    {
+        using var fixture = new Fixture();
+        fixture.SetupFailingCall(new RpcException(new Status(StatusCode.Unavailable, "not available")));
+        var sut = fixture.BuildSut();
+
+        var result = await sut.RunShortcutAsync("Shortcut", "input", CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().NotBeNullOrEmpty();
+    }
+
+    [TestMethod]
+    public async Task RunShortcutAsync_NullInput_TreatedAsEmpty()
+    {
+        using var fixture = new Fixture();
+        fixture.SetupSuccessCall(new RunShortcutResult { Success = true });
+        var sut = fixture.BuildSut();
+
+        var act = async () => await sut.RunShortcutAsync("Shortcut", null!, CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/backend/tests/Mozgoslav.Tests/Infrastructure/Prompts/MozgoslavPromptBuilderTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Infrastructure/Prompts/MozgoslavPromptBuilderTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Mozgoslav.Application.Rag;
+using Mozgoslav.Application.WebSearch;
+using Mozgoslav.Infrastructure.Prompts;
+
+using NSubstitute;
+
+namespace Mozgoslav.Tests.Infrastructure.Prompts;
+
+[TestClass]
+public sealed class MozgoslavPromptBuilderTests
+{
+    private sealed class Fixture
+    {
+        public IRagService RagService { get; } = Substitute.For<IRagService>();
+        public IWebSearch WebSearch { get; } = Substitute.For<IWebSearch>();
+
+        public MozgoslavPromptBuilder BuildSut() =>
+            new(RagService, WebSearch, NullLogger<MozgoslavPromptBuilder>.Instance);
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_NoPlaceholders_ReturnsTemplateUnchanged()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var result = await sut.BuildAsync("Hello world", new Dictionary<string, string>(), CancellationToken.None);
+
+        result.Should().Be("Hello world");
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_ContextKeyReplaced_SubstitutesValue()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+        var context = new Dictionary<string, string> { ["name"] = "Alice" };
+
+        var result = await sut.BuildAsync("Hello {name}!", context, CancellationToken.None);
+
+        result.Should().Be("Hello Alice!");
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_UnknownPlaceholder_LeftUnchanged()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var result = await sut.BuildAsync("{unknown}", new Dictionary<string, string>(), CancellationToken.None);
+
+        result.Should().Be("{unknown}");
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_PlaceholderWithArgs_LeftUnchangedWhenUnknown()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var result = await sut.BuildAsync("{action(arg1)}", new Dictionary<string, string>(), CancellationToken.None);
+
+        result.Should().Be("{action(arg1)}");
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_MultipleContextKeys_ReplacesAll()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+        var context = new Dictionary<string, string>
+        {
+            ["first"] = "FIRST",
+            ["second"] = "SECOND"
+        };
+
+        var result = await sut.BuildAsync("A={first} B={second}", context, CancellationToken.None);
+
+        result.Should().Be("A=FIRST B=SECOND");
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_NullTemplate_ThrowsArgumentNullException()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var act = async () => await sut.BuildAsync(null!, new Dictionary<string, string>(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_NullContext_ThrowsArgumentNullException()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var act = async () => await sut.BuildAsync("template", null!, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_ContextAndPlaceholder_ContextReplacesThenUnknownLeft()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+        var context = new Dictionary<string, string> { ["greeting"] = "Hi" };
+
+        var result = await sut.BuildAsync("{greeting} {stranger}", context, CancellationToken.None);
+
+        result.Should().StartWith("Hi ");
+        result.Should().Contain("{stranger}");
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_EmptyTemplate_ReturnsEmpty()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var result = await sut.BuildAsync(string.Empty, new Dictionary<string, string>(), CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+}

--- a/backend/tests/Mozgoslav.Tests/Infrastructure/Prompts/PromptDispatcherTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Infrastructure/Prompts/PromptDispatcherTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Mozgoslav.Application.Interfaces;
+using Mozgoslav.Infrastructure.Prompts;
+
+using NSubstitute;
+
+namespace Mozgoslav.Tests.Infrastructure.Prompts;
+
+[TestClass]
+public sealed class PromptDispatcherTests
+{
+    private sealed class Fixture
+    {
+        public IAppSettings Settings { get; } = Substitute.For<IAppSettings>();
+
+        public PromptDispatcher BuildSut() =>
+            new(Settings, NullLogger<PromptDispatcher>.Instance);
+    }
+
+    [TestMethod]
+    public async Task DispatchAsync_NullPrompt_ThrowsArgumentException()
+    {
+        var fixture = new Fixture();
+        fixture.Settings.ClaudeCliPath.Returns(string.Empty);
+        var sut = fixture.BuildSut();
+
+        var act = async () => await sut.DispatchAsync(null!, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [TestMethod]
+    public async Task DispatchAsync_WhitespacePrompt_ThrowsArgumentException()
+    {
+        var fixture = new Fixture();
+        fixture.Settings.ClaudeCliPath.Returns(string.Empty);
+        var sut = fixture.BuildSut();
+
+        var act = async () => await sut.DispatchAsync("   ", CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [TestMethod]
+    public async Task DispatchAsync_NoCliPath_NonMac_DoesNotThrow()
+    {
+        var fixture = new Fixture();
+        fixture.Settings.ClaudeCliPath.Returns(string.Empty);
+        var sut = fixture.BuildSut();
+
+        var act = async () => await sut.DispatchAsync("some prompt text", CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [TestMethod]
+    public async Task DispatchAsync_CliPathNotFound_FallsBackGracefully()
+    {
+        var fixture = new Fixture();
+        fixture.Settings.ClaudeCliPath.Returns("/nonexistent/path/to/claude");
+        var sut = fixture.BuildSut();
+
+        var act = async () => await sut.DispatchAsync("hello", CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/backend/tests/Mozgoslav.Tests/Infrastructure/Prompts/PromptTemplateRepositoryTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Infrastructure/Prompts/PromptTemplateRepositoryTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+using Mozgoslav.Application.Prompts;
+using Mozgoslav.Infrastructure.Persistence;
+using Mozgoslav.Infrastructure.Prompts;
+
+namespace Mozgoslav.Tests.Infrastructure.Prompts;
+
+[TestClass]
+public sealed class PromptTemplateRepositoryTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly MozgoslavDbContext _db;
+
+    public PromptTemplateRepositoryTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<MozgoslavDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        _db = new MozgoslavDbContext(options);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        _connection.Dispose();
+    }
+
+    private PromptTemplateRepository BuildSut() => new(_db);
+
+    [TestMethod]
+    public async Task AddAsync_PersistsTemplate_CanBeRetrievedById()
+    {
+        var template = new PromptTemplate(Guid.NewGuid(), "My Template", "Hello {name}", DateTimeOffset.UtcNow);
+        var sut = BuildSut();
+
+        var added = await sut.AddAsync(template, CancellationToken.None);
+        var retrieved = await sut.GetByIdAsync(added.Id, CancellationToken.None);
+
+        retrieved.Should().NotBeNull();
+        retrieved!.Name.Should().Be("My Template");
+        retrieved.Body.Should().Be("Hello {name}");
+    }
+
+    [TestMethod]
+    public async Task GetByIdAsync_UnknownId_ReturnsNull()
+    {
+        var sut = BuildSut();
+
+        var result = await sut.GetByIdAsync(Guid.NewGuid(), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task GetAllAsync_ReturnsAllTemplatesOrderedByName()
+    {
+        var sut = BuildSut();
+        await sut.AddAsync(new PromptTemplate(Guid.NewGuid(), "Zzz", "body z", DateTimeOffset.UtcNow), CancellationToken.None);
+        await sut.AddAsync(new PromptTemplate(Guid.NewGuid(), "Aaa", "body a", DateTimeOffset.UtcNow), CancellationToken.None);
+
+        var all = await sut.GetAllAsync(CancellationToken.None);
+
+        all.Should().HaveCount(2);
+        all[0].Name.Should().Be("Aaa");
+        all[1].Name.Should().Be("Zzz");
+    }
+
+    [TestMethod]
+    public async Task UpdateAsync_ModifiesNameAndBody()
+    {
+        var sut = BuildSut();
+        var id = Guid.NewGuid();
+        await sut.AddAsync(new PromptTemplate(id, "Old Name", "Old Body", DateTimeOffset.UtcNow), CancellationToken.None);
+
+        await sut.UpdateAsync(new PromptTemplate(id, "New Name", "New Body", DateTimeOffset.UtcNow), CancellationToken.None);
+
+        var updated = await sut.GetByIdAsync(id, CancellationToken.None);
+        updated!.Name.Should().Be("New Name");
+        updated.Body.Should().Be("New Body");
+    }
+
+    [TestMethod]
+    public async Task TryDeleteAsync_ExistingId_RemovesAndReturnsTrue()
+    {
+        var sut = BuildSut();
+        var id = Guid.NewGuid();
+        await sut.AddAsync(new PromptTemplate(id, "To Delete", "body", DateTimeOffset.UtcNow), CancellationToken.None);
+
+        var deleted = await sut.TryDeleteAsync(id, CancellationToken.None);
+        var after = await sut.GetByIdAsync(id, CancellationToken.None);
+
+        deleted.Should().BeTrue();
+        after.Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task TryDeleteAsync_UnknownId_ReturnsFalse()
+    {
+        var sut = BuildSut();
+
+        var result = await sut.TryDeleteAsync(Guid.NewGuid(), CancellationToken.None);
+
+        result.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task UpdateAsync_UnknownId_DoesNotThrow()
+    {
+        var sut = BuildSut();
+
+        var act = async () => await sut.UpdateAsync(
+            new PromptTemplate(Guid.NewGuid(), "Ghost", "nobody home", DateTimeOffset.UtcNow),
+            CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/backend/tests/Mozgoslav.Tests/Infrastructure/Prompts/PromptTemplateRepositoryTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Infrastructure/Prompts/PromptTemplateRepositoryTests.cs
@@ -50,7 +50,7 @@ public sealed class PromptTemplateRepositoryTests : IDisposable
         var retrieved = await sut.GetByIdAsync(added.Id, CancellationToken.None);
 
         retrieved.Should().NotBeNull();
-        retrieved!.Name.Should().Be("My Template");
+        retrieved.Name.Should().Be("My Template");
         retrieved.Body.Should().Be("Hello {name}");
     }
 

--- a/backend/tests/Mozgoslav.Tests/Infrastructure/Routines/RoutineRegistryTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Infrastructure/Routines/RoutineRegistryTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Mozgoslav.Application.Agents.Skills;
+using Mozgoslav.Application.Interfaces;
+using Mozgoslav.Application.Routines;
+using Mozgoslav.Domain.Entities;
+using Mozgoslav.Infrastructure.Routines;
+
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace Mozgoslav.Tests.Infrastructure.Routines;
+
+[TestClass]
+public sealed class RoutineRegistryTests
+{
+    private sealed class Fixture
+    {
+        public IAppSettings Settings { get; } = Substitute.For<IAppSettings>();
+        public IRoutineRunRepository RunRepository { get; } = Substitute.For<IRoutineRunRepository>();
+        public IActionExtractorSkill ActionExtractorSkill { get; } = Substitute.For<IActionExtractorSkill>();
+        public IRemindersSkill RemindersSkill { get; } = Substitute.For<IRemindersSkill>();
+
+        public Fixture()
+        {
+            RunRepository.AddAsync(Arg.Any<RoutineRun>(), Arg.Any<CancellationToken>())
+                .Returns(ci => ci.Arg<RoutineRun>());
+            RunRepository.UpdateAsync(Arg.Any<RoutineRun>(), Arg.Any<CancellationToken>())
+                .Returns(Task.CompletedTask);
+            RunRepository.TryGetLatestAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns((RoutineRun?)null);
+            Settings.Snapshot.Returns(AppSettingsDto.Defaults);
+            Settings.SaveAsync(Arg.Any<AppSettingsDto>(), Arg.Any<CancellationToken>())
+                .Returns(Task.CompletedTask);
+        }
+
+        public RoutineRegistry BuildSut() =>
+            new(Settings, RunRepository, ActionExtractorSkill, RemindersSkill,
+                NullLogger<RoutineRegistry>.Instance);
+    }
+
+    [TestMethod]
+    public async Task ListAsync_ReturnsTwoRoutines()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var list = await sut.ListAsync(CancellationToken.None);
+
+        list.Should().HaveCount(2);
+        list.Should().Contain(r => r.Key == "action-extractor");
+        list.Should().Contain(r => r.Key == "reminders");
+    }
+
+    [TestMethod]
+    public async Task ListAsync_ReflectsSkillEnabledFromSettings()
+    {
+        var fixture = new Fixture();
+        fixture.Settings.ActionsSkillEnabled.Returns(true);
+        fixture.Settings.RemindersSkillEnabled.Returns(false);
+        var sut = fixture.BuildSut();
+
+        var list = await sut.ListAsync(CancellationToken.None);
+
+        list.Should().Contain(r => r.Key == "action-extractor" && r.IsEnabled);
+        list.Should().Contain(r => r.Key == "reminders" && !r.IsEnabled);
+    }
+
+    [TestMethod]
+    public async Task RunNowAsync_ActionExtractorKey_SetsSucceeded()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var run = await sut.RunNowAsync("action-extractor", CancellationToken.None);
+
+        run.Status.Should().Be("Succeeded");
+        await fixture.RunRepository.Received(1).AddAsync(Arg.Any<RoutineRun>(), Arg.Any<CancellationToken>());
+        await fixture.RunRepository.Received(1).UpdateAsync(Arg.Any<RoutineRun>(), Arg.Any<CancellationToken>());
+    }
+
+    [TestMethod]
+    public async Task RunNowAsync_RemindersKey_CallsRemindersSkillAndSucceeds()
+    {
+        var fixture = new Fixture();
+        fixture.RemindersSkill.CreateAsync(Arg.Any<IReadOnlyList<ActionItem>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var sut = fixture.BuildSut();
+
+        var run = await sut.RunNowAsync("reminders", CancellationToken.None);
+
+        run.Status.Should().Be("Succeeded");
+        await fixture.RemindersSkill.Received(1)
+            .CreateAsync(Arg.Any<IReadOnlyList<ActionItem>>(), Arg.Any<CancellationToken>());
+    }
+
+    [TestMethod]
+    public async Task RunNowAsync_UnknownKey_SetsFailed()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var run = await sut.RunNowAsync("unknown-key", CancellationToken.None);
+
+        run.Status.Should().Be("Failed");
+        run.ErrorMessage.Should().Contain("Unknown routine key");
+    }
+
+    [TestMethod]
+    public async Task RunNowAsync_EmptyKey_ThrowsArgumentException()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var act = async () => await sut.RunNowAsync("", CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [TestMethod]
+    public async Task RunNowAsync_SkillThrows_StatusIsFailed()
+    {
+        var fixture = new Fixture();
+        fixture.RemindersSkill.CreateAsync(Arg.Any<IReadOnlyList<ActionItem>>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("skill broke"));
+        var sut = fixture.BuildSut();
+
+        var run = await sut.RunNowAsync("reminders", CancellationToken.None);
+
+        run.Status.Should().Be("Failed");
+        run.ErrorMessage.Should().Contain("skill broke");
+    }
+
+    [TestMethod]
+    public async Task ToggleAsync_ActionExtractorKey_SavesActionsSkillEnabled()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        await sut.ToggleAsync("action-extractor", enabled: true, CancellationToken.None);
+
+        await fixture.Settings.Received(1).SaveAsync(
+            Arg.Is<AppSettingsDto>(d => d.ActionsSkillEnabled),
+            Arg.Any<CancellationToken>());
+    }
+
+    [TestMethod]
+    public async Task ToggleAsync_RemindersKey_SavesRemindersSkillEnabled()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        await sut.ToggleAsync("reminders", enabled: false, CancellationToken.None);
+
+        await fixture.Settings.Received(1).SaveAsync(
+            Arg.Is<AppSettingsDto>(d => !d.RemindersSkillEnabled),
+            Arg.Any<CancellationToken>());
+    }
+
+    [TestMethod]
+    public async Task ToggleAsync_UnknownKey_ThrowsInvalidOperationException()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var act = async () => await sut.ToggleAsync("bad-key", true, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+}

--- a/backend/tests/Mozgoslav.Tests/Infrastructure/Services/MeetilyImporterServiceTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Infrastructure/Services/MeetilyImporterServiceTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Mozgoslav.Application.Interfaces;
+using Mozgoslav.Infrastructure.Services;
+
+using NSubstitute;
+
+namespace Mozgoslav.Tests.Infrastructure.Services;
+
+[TestClass]
+public sealed class MeetilyImporterServiceTests
+{
+    private sealed class Fixture
+    {
+        public IRecordingRepository Recordings { get; } = Substitute.For<IRecordingRepository>();
+        public ITranscriptRepository Transcripts { get; } = Substitute.For<ITranscriptRepository>();
+
+        public MeetilyImporterService BuildSut() =>
+            new(Recordings, Transcripts, NullLogger<MeetilyImporterService>.Instance);
+    }
+
+    private static async Task<string> CreateMeetilyDbAsync(bool withMeetingRow = false)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"meetily-test-{Guid.NewGuid():N}.db");
+        await using var conn = new SqliteConnection($"DataSource={path}");
+        await conn.OpenAsync();
+
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = """
+                CREATE TABLE meetings (
+                    id TEXT PRIMARY KEY,
+                    title TEXT,
+                    audio_path TEXT,
+                    created_at TEXT
+                )
+                """;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = """
+                CREATE TABLE transcripts (
+                    id TEXT PRIMARY KEY,
+                    meeting_id TEXT,
+                    text TEXT
+                )
+                """;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        if (withMeetingRow)
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "INSERT INTO meetings (id, title, audio_path, created_at) VALUES ('m1', 'Test', NULL, '2026-01-01T10:00:00Z')";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        return path;
+    }
+
+    [TestMethod]
+    public async Task ImportAsync_NullPath_ThrowsArgumentException()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var act = async () => await sut.ImportAsync(null!, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [TestMethod]
+    public async Task ImportAsync_WhitespacePath_ThrowsArgumentException()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var act = async () => await sut.ImportAsync("   ", CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [TestMethod]
+    public async Task ImportAsync_NonExistentFile_ThrowsFileNotFoundException()
+    {
+        var fixture = new Fixture();
+        var sut = fixture.BuildSut();
+
+        var act = async () => await sut.ImportAsync("/tmp/this-file-does-not-exist-xyz.db", CancellationToken.None);
+
+        await act.Should().ThrowAsync<FileNotFoundException>();
+    }
+
+    [TestMethod]
+    public async Task ImportAsync_DbWithoutMeetilySchema_ThrowsInvalidOperationException()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"empty-{Guid.NewGuid():N}.db");
+        try
+        {
+            await using (var conn = new SqliteConnection($"DataSource={path}"))
+            {
+                await conn.OpenAsync();
+                await using var cmd = conn.CreateCommand();
+                cmd.CommandText = "CREATE TABLE other_table (id TEXT)";
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            var fixture = new Fixture();
+            var sut = fixture.BuildSut();
+            var act = async () => await sut.ImportAsync(path, CancellationToken.None);
+
+            await act.Should().ThrowAsync<InvalidOperationException>();
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [TestMethod]
+    public async Task ImportAsync_EmptyMeetingsTable_ReturnsZeroCounts()
+    {
+        var path = await CreateMeetilyDbAsync();
+        try
+        {
+            var fixture = new Fixture();
+            var sut = fixture.BuildSut();
+
+            var report = await sut.ImportAsync(path, CancellationToken.None);
+
+            report.TotalMeetings.Should().Be(0);
+            report.ImportedRecordings.Should().Be(0);
+            report.SkippedDuplicates.Should().Be(0);
+            report.Errors.Should().Be(0);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [TestMethod]
+    public async Task ImportAsync_MeetingWithNullAudioPath_SkipsEntry()
+    {
+        var path = await CreateMeetilyDbAsync(withMeetingRow: true);
+        try
+        {
+            var fixture = new Fixture();
+            var sut = fixture.BuildSut();
+
+            var report = await sut.ImportAsync(path, CancellationToken.None);
+
+            report.TotalMeetings.Should().Be(1);
+            report.SkippedDuplicates.Should().Be(1);
+            report.ImportedRecordings.Should().Be(0);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+}

--- a/backend/tests/Mozgoslav.Tests/Infrastructure/Services/ModelDownloadCoordinatorTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Infrastructure/Services/ModelDownloadCoordinatorTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Mozgoslav.Infrastructure.Services;
+
+using NSubstitute;
+
+namespace Mozgoslav.Tests.Infrastructure.Services;
+
+[TestClass]
+public sealed class ModelDownloadCoordinatorTests
+{
+    private sealed class Fixture : IDisposable
+    {
+        private readonly CancellationTokenSource _hostCts = new();
+        private readonly IHttpClientFactory _httpClientFactory = Substitute.For<IHttpClientFactory>();
+        public IHostApplicationLifetime Lifetime { get; } = Substitute.For<IHostApplicationLifetime>();
+        public ModelDownloadService Downloader { get; }
+
+        public Fixture()
+        {
+            Lifetime.ApplicationStopping.Returns(_hostCts.Token);
+            Downloader = new ModelDownloadService(_httpClientFactory, NullLogger<ModelDownloadService>.Instance);
+        }
+
+        public ModelDownloadCoordinator BuildSut() =>
+            new(Downloader, NullLogger<ModelDownloadCoordinator>.Instance, Lifetime);
+
+        public void Dispose()
+        {
+            _hostCts.Dispose();
+        }
+    }
+
+    [TestMethod]
+    public void Start_BlankCatalogueId_ThrowsArgumentException()
+    {
+        using var fixture = new Fixture();
+        using var sut = fixture.BuildSut();
+
+        var act = () => sut.Start("", "http://example.com/model.bin", "/tmp/model.bin", CancellationToken.None);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [TestMethod]
+    public void Start_BlankUrl_ThrowsArgumentException()
+    {
+        using var fixture = new Fixture();
+        using var sut = fixture.BuildSut();
+
+        var act = () => sut.Start("my-model", "", "/tmp/model.bin", CancellationToken.None);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [TestMethod]
+    public void Start_BlankDestination_ThrowsArgumentException()
+    {
+        using var fixture = new Fixture();
+        using var sut = fixture.BuildSut();
+
+        var act = () => sut.Start("my-model", "http://example.com/model.bin", "", CancellationToken.None);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [TestMethod]
+    public void Start_ValidArgs_ReturnsNonEmptyDownloadId()
+    {
+        using var fixture = new Fixture();
+        using var sut = fixture.BuildSut();
+
+        var id = sut.Start("my-model", "http://example.com/model.bin", "/tmp/model.bin", CancellationToken.None);
+
+        id.Should().NotBeNullOrEmpty();
+    }
+
+    [TestMethod]
+    public void Start_CalledTwice_ReturnsDifferentDownloadIds()
+    {
+        using var fixture = new Fixture();
+        using var sut = fixture.BuildSut();
+
+        var id1 = sut.Start("model-a", "http://example.com/a.bin", "/tmp/a.bin", CancellationToken.None);
+        var id2 = sut.Start("model-b", "http://example.com/b.bin", "/tmp/b.bin", CancellationToken.None);
+
+        id1.Should().NotBe(id2);
+    }
+
+    [TestMethod]
+    public async Task StreamAsync_UnknownDownloadId_YieldsDoneWithError()
+    {
+        using var fixture = new Fixture();
+        using var sut = fixture.BuildSut();
+
+        var events = new List<ModelDownloadProgress>();
+        await foreach (var p in sut.StreamAsync("unknown-id", CancellationToken.None))
+        {
+            events.Add(p);
+        }
+
+        events.Should().HaveCount(1);
+        events[0].Done.Should().BeTrue();
+        events[0].Error.Should().Be("unknown-download-id");
+    }
+
+    [TestMethod]
+    public async Task StreamAsync_Cancellation_EventuallyYieldsDoneProgress()
+    {
+        using var fixture = new Fixture();
+        using var sut = fixture.BuildSut();
+
+        using var cts = new CancellationTokenSource();
+        var downloadId = sut.Start("model", "http://localhost:9/nonexistent.bin", "/tmp/test-model.bin", cts.Token);
+
+        await cts.CancelAsync();
+
+        var events = new List<ModelDownloadProgress>();
+        using var streamCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        try
+        {
+            await foreach (var p in sut.StreamAsync(downloadId, streamCts.Token))
+            {
+                events.Add(p);
+                if (p.Done) break;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        events.Should().NotBeEmpty();
+        events.Last().Done.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Dispose_WithActiveDownload_DoesNotThrow()
+    {
+        var act = () =>
+        {
+            using var fixture = new Fixture();
+            using var sut = fixture.BuildSut();
+            sut.Start("x", "http://localhost/x.bin", "/tmp/x.bin", CancellationToken.None);
+        };
+
+        act.Should().NotThrow();
+    }
+}

--- a/backend/tests/Mozgoslav.Tests/Tooling/RunsettingsCoverageInstrumentationTests.cs
+++ b/backend/tests/Mozgoslav.Tests/Tooling/RunsettingsCoverageInstrumentationTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+using FluentAssertions;
+
+namespace Mozgoslav.Tests.Tooling;
+
+[TestClass]
+public sealed class RunsettingsCoverageInstrumentationTests
+{
+    private static readonly string BackendRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+
+    private static string UnitSettingsPath => Path.Combine(BackendRoot, "UnitTests.runsettings");
+
+    private static string IntegrationSettingsPath => Path.Combine(BackendRoot, "IntegrationTests.runsettings");
+
+    [TestMethod]
+    public void UnitSettings_Include_contains_MozgoslavApi()
+    {
+        var include = ReadCoverletElement(UnitSettingsPath, "Include");
+        include.Should().Contain("[Mozgoslav.Api]*");
+    }
+
+    [TestMethod]
+    public void IntegrationSettings_Include_contains_MozgoslavApi()
+    {
+        var include = ReadCoverletElement(IntegrationSettingsPath, "Include");
+        include.Should().Contain("[Mozgoslav.Api]*");
+    }
+
+    [TestMethod]
+    public void UnitSettings_ExcludeByFile_excludes_obj_generated_sources()
+    {
+        var excludeByFile = ReadCoverletElement(UnitSettingsPath, "ExcludeByFile");
+        excludeByFile.Should().Contain("**/obj/**");
+    }
+
+    [TestMethod]
+    public void IntegrationSettings_ExcludeByFile_excludes_obj_generated_sources()
+    {
+        var excludeByFile = ReadCoverletElement(IntegrationSettingsPath, "ExcludeByFile");
+        excludeByFile.Should().Contain("**/obj/**");
+    }
+
+    private static string ReadCoverletElement(string runsettingsPath, string elementName)
+    {
+        File.Exists(runsettingsPath).Should().BeTrue(
+            $"runsettings file must exist at {runsettingsPath}");
+
+        var doc = XDocument.Load(runsettingsPath);
+
+        var elements = doc
+            .Descendants("Configuration")
+            .SelectMany(c => c.Elements(elementName))
+            .ToList();
+
+        elements.Should().NotBeEmpty(
+            $"<{elementName}> must be present inside coverlet <Configuration> in {runsettingsPath}");
+
+        return elements[0].Value;
+    }
+}


### PR DESCRIPTION
Closes #274
Closes #275
Closes #276
Closes #277
Closes #278

Manual verification:
- [ ] After merge, post-checks/coverage comment reports backend % ≥ 46% (was 40.82%).
- [ ] Native lcov denominator drops to ~1-5K lines (was 167609); native % becomes meaningful.
- [ ] cobertura no longer shows `obj/Debug/.../DictationHelper*.cs` entries.
- [ ] `Mozgoslav.Api.Models.ModelCatalog` and `RecordingSessionRegistry` show non-zero coverage.